### PR TITLE
Secure logging and alerts

### DIFF
--- a/backend/orchestrator/logging.py
+++ b/backend/orchestrator/logging.py
@@ -1,0 +1,25 @@
+import os
+from typing import Any, Dict
+
+import requests
+
+LOG_INDEXER_URL = os.environ.get("LOG_INDEXER_URL")
+AUTH_TOKEN = os.environ.get("AUTH_TOKEN")
+
+
+def log_event(service: str, message: str, extra: Dict[str, Any] | None = None) -> None:
+    """Send a log event to the central log indexer."""
+    if not LOG_INDEXER_URL or not AUTH_TOKEN:
+        return
+    payload = {"service": service, "message": message}
+    if extra:
+        payload.update(extra)
+    try:
+        requests.post(
+            f"{LOG_INDEXER_URL}/log",
+            json=payload,
+            headers={"Authorization": f"Bearer {AUTH_TOKEN}"},
+            timeout=5,
+        )
+    except Exception:
+        pass

--- a/backend/orchestrator/main.py
+++ b/backend/orchestrator/main.py
@@ -4,7 +4,7 @@ from typing import Dict, List
 from fastapi import FastAPI, HTTPException, Request
 from pydantic import BaseModel
 
-from common.logging import log_event
+from .logging import log_event
 
 VERSION = "0.1.0"
 
@@ -20,6 +20,10 @@ def _auth(request: Request) -> None:
 
 class World(BaseModel):
     name: str
+
+
+class Alert(BaseModel):
+    detail: str
 
 @app.get("/health")
 async def health() -> Dict[str, str]:
@@ -52,3 +56,10 @@ async def delete_world(world_id: int, request: Request) -> Dict[str, str]:
         raise HTTPException(status_code=404, detail="World not found")
     log_event("orchestrator", f"world deleted: {name}")
     return {"status": "deleted"}
+
+
+@app.post("/alerts")
+async def alerts(alert: Alert, request: Request) -> Dict[str, str]:
+    _auth(request)
+    log_event("orchestrator", f"alert received: {alert.detail}")
+    return {"status": "ok"}

--- a/backend/orchestrator/requirements.txt
+++ b/backend/orchestrator/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.110.0
+uvicorn==0.29.0
+requests==2.31.0
+pydantic==2.6.4

--- a/behavior_analytics/Dockerfile
+++ b/behavior_analytics/Dockerfile
@@ -1,6 +1,10 @@
-FROM python:3.11-slim
+FROM python:3.11.6-slim
 WORKDIR /app
+
+COPY behavior_analytics/requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
 COPY behavior_analytics /app
-RUN pip install fastapi uvicorn requests pydantic pydantic-settings
+
 EXPOSE 80
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "80"]

--- a/behavior_analytics/main.py
+++ b/behavior_analytics/main.py
@@ -14,8 +14,14 @@ async def health() -> dict:
 
 def _log(message: str) -> None:
     settings = get_settings()
+    headers = {"Authorization": f"Bearer {settings.auth_token}"}
     try:
-        requests.post(settings.log_indexer_url, json={"service": "behavior_analytics", "message": message})
+        requests.post(
+            f"{settings.log_indexer_url}/log",
+            json={"service": "behavior_analytics", "message": message},
+            headers=headers,
+            timeout=5,
+        )
     except Exception:
         pass
 

--- a/behavior_analytics/requirements.txt
+++ b/behavior_analytics/requirements.txt
@@ -1,0 +1,5 @@
+fastapi==0.110.0
+uvicorn==0.29.0
+requests==2.31.0
+pydantic==2.6.4
+pydantic-settings==2.2.1

--- a/infra/orchestrator.Dockerfile
+++ b/infra/orchestrator.Dockerfile
@@ -1,7 +1,10 @@
-FROM python:3.11-slim
+FROM python:3.11.6-slim
 WORKDIR /app
+
+COPY backend/orchestrator/requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
 COPY backend/orchestrator /app
-COPY backend/common /app/common
-RUN pip install fastapi uvicorn requests
+
 EXPOSE 80
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "80"]


### PR DESCRIPTION
## Summary
- secure Behavior Analytics logging with auth headers and timeout
- add orchestrator alert endpoint and local logging helper
- pin dependencies with per-service requirements and slim Python base images

## Testing
- `pytest tests/test_health.py::test_health_endpoints -q` *(fails: FileNotFoundError: No such file or directory: 'docker')*

------
https://chatgpt.com/codex/tasks/task_e_68953383fa84832c92e8907dfdf9cae9