### PR TITLE
Fix orchestrator Dockerfile paths

### DIFF
--- a/infra/orchestrator.Dockerfile
+++ b/infra/orchestrator.Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 COPY backend/orchestrator/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY backend/orchestrator /app
+COPY backend/orchestrator/ .
 
 EXPOSE 80
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "80"]


### PR DESCRIPTION
## Summary
- copy orchestrator requirements and code from backend/orchestrator

## Testing
- `docker compose -f infra/docker-compose.yml up --build` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_6895485669d4832caec1f03d5de3b234