### PR TITLE
Add infrastructure scaffolding script and regenerate Docker setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,30 +1,83 @@
-version: '3.9'
+version: "3.9"
+
+x-service-base: &service-base
+  restart: unless-stopped
+  env_file:
+    - .env
+  networks:
+    - app_net
+
+x-healthcheck-curl: &healthcheck-curl
+  interval: 30s
+  timeout: 10s
+  retries: 3
+  start_period: 10s
+
 services:
   orchestrator:
+    <<: *service-base
     build:
       context: .
       dockerfile: infra/orchestrator.Dockerfile
+    container_name: orchestrator
     ports:
       - "8000:8000"
     depends_on:
-      - sentinel_core
-      - sentinel_red
-      - log_indexer
+      log_indexer:
+        condition: service_healthy
+      sentinel_core:
+        condition: service_started
+      sentinel_red:
+        condition: service_started
+    healthcheck:
+      <<: *healthcheck-curl
+      test: ["CMD-SHELL", "curl -fsS http://localhost:8000/health || exit 1"]
   sentinel_core:
+    <<: *service-base
     build:
       context: .
       dockerfile: infra/sentinel_core.Dockerfile
+    container_name: sentinel_core
     ports:
-      - "8001:8000"
+      - "8001:8001"
+    depends_on:
+      log_indexer:
+        condition: service_healthy
+    healthcheck:
+      <<: *healthcheck-curl
+      test: ["CMD-SHELL", "curl -fsS http://localhost:8001/health || exit 1"]
   sentinel_red:
+    <<: *service-base
     build:
       context: .
       dockerfile: infra/sentinel_red.Dockerfile
+    container_name: sentinel_red
     ports:
-      - "8002:8000"
+      - "8002:8002"
+    depends_on:
+      log_indexer:
+        condition: service_healthy
+    healthcheck:
+      <<: *healthcheck-curl
+      test: ["CMD-SHELL", "curl -fsS http://localhost:8002/health || exit 1"]
   log_indexer:
+    <<: *service-base
     build:
       context: .
       dockerfile: infra/log_indexer.Dockerfile
+    container_name: log_indexer
     ports:
-      - "8003:8000"
+      - "8003:8003"
+    healthcheck:
+      <<: *healthcheck-curl
+      test: ["CMD-SHELL", "curl -fsS http://localhost:8003/health || exit 1"]
+    volumes:
+      - log_data:/var/log/sentinel_foundry/
+
+volumes:
+  log_data:
+    driver: local
+
+networks:
+  app_net:
+    driver: bridge

--- a/infra/log_indexer.Dockerfile
+++ b/infra/log_indexer.Dockerfile
@@ -2,5 +2,8 @@ FROM python:3.11-slim
 WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
-COPY log_indexer/ /app
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+COPY ./log_indexer/ .
+EXPOSE 8003
+RUN useradd -m appuser
+USER appuser
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8003"]

--- a/infra/orchestrator.Dockerfile
+++ b/infra/orchestrator.Dockerfile
@@ -2,5 +2,8 @@ FROM python:3.11-slim
 WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
-COPY orchestrator/ /app
+COPY ./orchestrator/ .
+EXPOSE 8000
+RUN useradd -m appuser
+USER appuser
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/infra/sentinel_core.Dockerfile
+++ b/infra/sentinel_core.Dockerfile
@@ -2,5 +2,8 @@ FROM python:3.11-slim
 WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
-COPY sentinel_core/ /app
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+COPY ./sentinel_core/ .
+EXPOSE 8001
+RUN useradd -m appuser
+USER appuser
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8001"]

--- a/infra/sentinel_red.Dockerfile
+++ b/infra/sentinel_red.Dockerfile
@@ -2,5 +2,8 @@ FROM python:3.11-slim
 WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
-COPY sentinel_red/ /app
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+COPY ./sentinel_red/ .
+EXPOSE 8002
+RUN useradd -m appuser
+USER appuser
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8002"]

--- a/scripts/scaffold.sh
+++ b/scripts/scaffold.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+set -e
+
+INFRA_DIR="./infra"
+BACKEND_DIR="."
+
+# Define services and their ports
+services=(
+  orchestrator
+  sentinel_core
+  sentinel_red
+  log_indexer
+)
+
+declare -A svc_ports=(
+  [orchestrator]=8000
+  [sentinel_core]=8001
+  [sentinel_red]=8002
+  [log_indexer]=8003
+)
+
+echo "== Cleaning existing Dockerfiles and docker-compose.yml =="
+rm -f "$INFRA_DIR"/*.Dockerfile
+rm -f docker-compose.yml
+
+echo "== Recreating Dockerfiles =="
+for svc in "${services[@]}"; do
+  cat > "$INFRA_DIR/${svc}.Dockerfile" <<DOCKER
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY $BACKEND_DIR/$svc/ .
+EXPOSE ${svc_ports[$svc]}
+RUN useradd -m appuser
+USER appuser
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "${svc_ports[$svc]}"]
+DOCKER
+  echo "Created Dockerfile for $svc"
+done
+
+echo "== Creating docker-compose.yml =="
+cat > docker-compose.yml <<'COMPOSE'
+version: "3.9"
+
+x-service-base: &service-base
+  restart: unless-stopped
+  env_file:
+    - .env
+  networks:
+    - app_net
+
+x-healthcheck-curl: &healthcheck-curl
+  interval: 30s
+  timeout: 10s
+  retries: 3
+  start_period: 10s
+
+services:
+COMPOSE
+
+for svc in "${services[@]}"; do
+  cat >> docker-compose.yml <<COMPOSE
+  $svc:
+    <<: *service-base
+    build:
+      context: .
+      dockerfile: infra/${svc}.Dockerfile
+    container_name: $svc
+    ports:
+      - "${svc_ports[$svc]}:${svc_ports[$svc]}"
+COMPOSE
+
+  if [[ "$svc" != "log_indexer" ]]; then
+    cat >> docker-compose.yml <<COMPOSE
+    depends_on:
+      log_indexer:
+        condition: service_healthy
+COMPOSE
+    if [[ "$svc" == "orchestrator" ]]; then
+      cat >> docker-compose.yml <<COMPOSE
+      sentinel_core:
+        condition: service_started
+      sentinel_red:
+        condition: service_started
+COMPOSE
+    fi
+  fi
+
+  cat >> docker-compose.yml <<COMPOSE
+    healthcheck:
+      <<: *healthcheck-curl
+      test: ["CMD-SHELL", "curl -fsS http://localhost:${svc_ports[$svc]}/health || exit 1"]
+COMPOSE
+
+  if [[ "$svc" == "log_indexer" ]]; then
+    cat >> docker-compose.yml <<COMPOSE
+    volumes:
+      - log_data:/var/log/sentinel_foundry/
+COMPOSE
+  fi
+
+done
+
+cat >> docker-compose.yml <<'COMPOSE'
+
+volumes:
+  log_data:
+    driver: local
+
+networks:
+  app_net:
+    driver: bridge
+COMPOSE
+
+echo "== Scaffold complete =="


### PR DESCRIPTION
## Summary
- add bash script to generate service Dockerfiles and docker-compose configuration
- include healthchecks, per-service ports, and user permissions in generated containers

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68954fc16210832c8b59cd9aa3b9621f