### PR TITLE
[forge-004] Enforce non-root users and pin base images

### DIFF
--- a/backend/behavior_analytics/Dockerfile
+++ b/backend/behavior_analytics/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.11.9-slim@sha256:2856e6af199e8128161abd320575eb9b341f3b76f017b5d0c9cd364f60d8a050
 
 RUN useradd -m appuser
 WORKDIR /app

--- a/backend/log_indexer/Dockerfile
+++ b/backend/log_indexer/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.11.9-slim@sha256:2856e6af199e8128161abd320575eb9b341f3b76f017b5d0c9cd364f60d8a050
 
 RUN useradd -m appuser
 WORKDIR /app

--- a/backend/mutation_engine/Dockerfile
+++ b/backend/mutation_engine/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.11.9-slim@sha256:2856e6af199e8128161abd320575eb9b341f3b76f017b5d0c9cd364f60d8a050
 
 RUN useradd -m appuser
 WORKDIR /app

--- a/backend/orchestrator/Dockerfile
+++ b/backend/orchestrator/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.11-slim
+FROM python:3.11.9-slim@sha256:2856e6af199e8128161abd320575eb9b341f3b76f017b5d0c9cd364f60d8a050
+RUN useradd -m appuser
 WORKDIR /app
 ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
 
@@ -9,6 +10,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl \
 COPY requirements.txt .
 RUN pip install -U pip && pip install --no-cache-dir -r requirements.txt
 COPY app ./app
+USER appuser
 EXPOSE 8000
 
 HEALTHCHECK --interval=20s --timeout=3s --retries=3 \

--- a/backend/sentinelcore/Dockerfile
+++ b/backend/sentinelcore/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.11.9-slim@sha256:2856e6af199e8128161abd320575eb9b341f3b76f017b5d0c9cd364f60d8a050
 
 RUN useradd -m appuser
 WORKDIR /app

--- a/backend/sentinelred/Dockerfile
+++ b/backend/sentinelred/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.11.9-slim@sha256:2856e6af199e8128161abd320575eb9b341f3b76f017b5d0c9cd364f60d8a050
 
 RUN useradd -m appuser
 WORKDIR /app

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine AS build
+FROM node:18.20.3-alpine3.19@sha256:4862d3c79737924e572a487b39a9e327acb517364e5e324c0f15067375c41f23 AS build
 WORKDIR /app
 COPY package*.json ./
 # no lockfile -> use npm install
@@ -6,10 +6,11 @@ RUN --mount=type=cache,target=/root/.npm npm install --no-audit --no-fund
 COPY . .
 RUN npm run build
 
-FROM nginxinc/nginx-unprivileged:stable-alpine AS runtime
+FROM nginxinc/nginx-unprivileged:1.25.3-alpine@sha256:46371dae8e17a9d22931d0e80a6c08e47f3b28ed449e0853a4fbb42f2c33f768 AS runtime
 WORKDIR /usr/share/nginx/html
 COPY --from=build /app/dist .
 COPY nginx.conf /etc/nginx/conf.d/default.conf
+USER 101
 EXPOSE 8080
 HEALTHCHECK --interval=20s --timeout=3s --retries=3 \
   CMD wget -qO- http://127.0.0.1:8080/ || exit 1

--- a/infra/frontend/Dockerfile
+++ b/infra/frontend/Dockerfile
@@ -1,14 +1,15 @@
-FROM node:18-alpine AS build
+FROM node:18.20.3-alpine3.19@sha256:4862d3c79737924e572a487b39a9e327acb517364e5e324c0f15067375c41f23 AS build
 WORKDIR /app
 COPY package*.json ./
 RUN --mount=type=cache,target=/root/.npm npm ci --quiet
 COPY . .
 RUN npm run build
 
-FROM nginxinc/nginx-unprivileged:stable-alpine AS runtime
+FROM nginxinc/nginx-unprivileged:1.25.3-alpine@sha256:46371dae8e17a9d22931d0e80a6c08e47f3b28ed449e0853a4fbb42f2c33f768 AS runtime
 WORKDIR /usr/share/nginx/html
 COPY --from=build /app/dist .
 COPY nginx.conf /etc/nginx/conf.d/default.conf
+USER 101
 EXPOSE 8080
 HEALTHCHECK --interval=20s --timeout=3s --retries=3 \
   CMD wget -qO- http://127.0.0.1:8080/ || exit 1

--- a/infra/log_indexer/Dockerfile
+++ b/infra/log_indexer/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.11-slim
+FROM python:3.11.9-slim@sha256:2856e6af199e8128161abd320575eb9b341f3b76f017b5d0c9cd364f60d8a050
+RUN useradd -m appuser
 WORKDIR /app
 ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
 RUN apt-get update && apt-get install -y --no-install-recommends curl \
@@ -6,6 +7,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl \
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 COPY indexer.py .
+USER appuser
 EXPOSE 8080
 HEALTHCHECK --interval=20s --timeout=3s --retries=3 \
   CMD curl -fsS http://127.0.0.1:8080/health || exit 1

--- a/infra/orchestrator/Dockerfile
+++ b/infra/orchestrator/Dockerfile
@@ -1,9 +1,11 @@
-FROM python:3.11-slim
+FROM python:3.11.9-slim@sha256:2856e6af199e8128161abd320575eb9b341f3b76f017b5d0c9cd364f60d8a050
+RUN useradd -m appuser
 WORKDIR /app
 ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
 COPY requirements.txt .
 RUN pip install -U pip && pip install --no-cache-dir -r requirements.txt
 COPY app ./app
+USER appuser
 EXPOSE 8000
 HEALTHCHECK --interval=20s --timeout=3s --retries=3 \
   CMD curl -fsS http://127.0.0.1:8000/ready || exit 1

--- a/log_indexer/Dockerfile
+++ b/log_indexer/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.11-slim
+FROM python:3.11.9-slim@sha256:2856e6af199e8128161abd320575eb9b341f3b76f017b5d0c9cd364f60d8a050
+RUN useradd -m appuser
 WORKDIR /app
 ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
 
@@ -9,6 +10,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl \
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 COPY indexer.py .
+USER appuser
 
 EXPOSE 8080
 # Hit unauthenticated /health so no token needed

--- a/orchestrator/Dockerfile
+++ b/orchestrator/Dockerfile
@@ -1,9 +1,11 @@
-FROM python:3.11-slim
+FROM python:3.11.9-slim@sha256:2856e6af199e8128161abd320575eb9b341f3b76f017b5d0c9cd364f60d8a050
 
+RUN useradd -m appuser
 WORKDIR /app
 COPY requirements.txt .
 RUN pip install -U pip && pip install --no-cache-dir -r requirements.txt
 
 COPY app ./app
+USER appuser
 EXPOSE 8000
 CMD ["uvicorn","app.main:app","--host","0.0.0.0","--port","8000"]


### PR DESCRIPTION
## Summary
- pin all service Dockerfiles to specific Node, Python, and nginx image digests
- drop root privileges via explicit service users in every container

## Testing
- `podman build orchestrator` *(fails: open libpod/tmp/pause.pid: no such file or directory)*
- `id -u appuser` -> 1001


------
https://chatgpt.com/codex/tasks/task_e_6897448386dc832ca21c6a60e9451e99