### PR TITLE
Parameterize GHCR images for overlay services

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -20,3 +20,13 @@ jobs:
           echo "Linting repo structure..."
           test -d .github && echo "✓ .github exists" || (echo "missing .github" && exit 1)
           echo "Audit complete."
+      - name: Ensure compose overlays use GHCR env interpolation
+        run: |
+          set -euo pipefail
+          for file in compose.federated.yml compose.staging.yml; do
+            if ! grep -q 'GITHUB_REPOSITORY_LC' "$file"; then
+              echo "::error::$file must reference GITHUB_REPOSITORY_LC"
+              exit 1
+            fi
+            echo "✓ $file"
+          done

--- a/compose.federated.yml
+++ b/compose.federated.yml
@@ -35,9 +35,7 @@ services:
     profiles:
       - range-plane
   fl_coordinator:
-    build:
-      context: .
-      dockerfile: services/fl_coordinator/Dockerfile
+    image: ghcr.io/${GITHUB_REPOSITORY_LC:-arescoreadmin/arescore-foundry}/fl_coordinator:latest
     depends_on:
       orchestrator:
         condition: service_started
@@ -51,9 +49,7 @@ services:
     profiles:
       - range-plane
   consent_registry:
-    build:
-      context: .
-      dockerfile: services/consent_registry/Dockerfile
+    image: ghcr.io/${GITHUB_REPOSITORY_LC:-arescoreadmin/arescore-foundry}/consent_registry:latest
     depends_on:
       orchestrator:
         condition: service_started
@@ -67,9 +63,7 @@ services:
     profiles:
       - range-plane
   evidence_bundler:
-    build:
-      context: .
-      dockerfile: services/evidence_bundler/Dockerfile
+    image: ghcr.io/${GITHUB_REPOSITORY_LC:-arescoreadmin/arescore-foundry}/evidence_bundler:latest
     depends_on:
       orchestrator:
         condition: service_started

--- a/compose.yml
+++ b/compose.yml
@@ -121,7 +121,7 @@ services:
     build:
       context: .
       dockerfile: services/ingestors/Dockerfile
-    image: ghcr.io/arescoreadmin/arescore-foundry/ingestors:latest
+    image: ghcr.io/${GITHUB_REPOSITORY_LC:-arescoreadmin/arescore-foundry}/ingestors:latest
     command: ["python", "-m", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]
     ports:
       - "8070:8080"

--- a/scripts/smoke_overlay.sh
+++ b/scripts/smoke_overlay.sh
@@ -5,6 +5,12 @@ set -euo pipefail
 COMPOSE="docker compose --profile control-plane --profile range-plane -f compose.yml -f compose.federated.yml"
 CURL="curl -fsS --max-time 3"
 
+# Allow overriding the GHCR namespace without requiring a .env file. Docker compose
+# will still honor a .env value if one is present, but this keeps the smoke test
+# self-contained.
+: "${GITHUB_REPOSITORY_LC:=arescoreadmin/arescore-foundry}"
+export GITHUB_REPOSITORY_LC
+
 RETRIES=${RETRIES:-40}
 SLEEP=${SLEEP:-1}
 


### PR DESCRIPTION
## Summary
- ensure the overlay docker compose files pull their container images from the GHCR namespace derived from `GITHUB_REPOSITORY_LC`
- set a default `GITHUB_REPOSITORY_LC` in the overlay smoke test so it stays self-contained
- add a lightweight audit step to guard the new compose expectations

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691529383ed8832c99a98d8da3a31244)