### PR TITLE
Fix orchestrator health accessibility in smoke overlay

### DIFF
--- a/services/orchestrator/entrypoint.sh
+++ b/services/orchestrator/entrypoint.sh
@@ -7,7 +7,15 @@ m = importlib.import_module("app.main")
 assert hasattr(m, "app"), "Expected 'app' in app.main (FastAPI instance)"
 PY
 
-UVICORN_HOST="${UVICORN_HOST:-0.0.0.0}"
+DEFAULT_HOST="0.0.0.0"
+UVICORN_HOST="${UVICORN_HOST:-$DEFAULT_HOST}"
 UVICORN_PORT="${UVICORN_PORT:-8080}"
+
+case "$UVICORN_HOST" in
+  "127.0.0.1"|"localhost"|"::1")
+    echo "[entrypoint] overriding loopback UVICORN_HOST=$UVICORN_HOST to $DEFAULT_HOST for container reachability" >&2
+    UVICORN_HOST="$DEFAULT_HOST"
+    ;;
+esac
 
 exec python -m uvicorn app.main:app --host "$UVICORN_HOST" --port "$UVICORN_PORT"


### PR DESCRIPTION
## Summary
- keep the orchestrator container reachable by overriding loopback-only UVICORN_HOST values to 0.0.0.0 before launching uvicorn

## Testing
- pytest services/orchestrator/app/tests -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69161167657c832ca88fda79880ddcf9)