### PR TITLE
Add in-memory consent registry API

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -5,3 +5,4 @@ pythonpath =
 testpaths =
     backend/frostgatecore/Tests
     services/tests
+    tests

--- a/services/consent_registry/app/main.py
+++ b/services/consent_registry/app/main.py
@@ -1,23 +1,150 @@
-from fastapi import FastAPI
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+from fastapi import FastAPI, HTTPException, status
+from pydantic import BaseModel, Field
+
 
 app = FastAPI(title="consent_registry")
 
+
+@dataclass
+class ConsentRecord:
+    """In-memory representation of a training consent."""
+
+    subject: str
+    token: str
+    metadata: dict[str, Any]
+    timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class ConsentRegistry:
+    """Stores training opt-in state for the smoke tests."""
+
+    def __init__(self) -> None:
+        self._records: dict[str, ConsentRecord] = {}
+
+    def opt_in(self, *, subject: str, token: str, metadata: dict[str, Any] | None) -> ConsentRecord:
+        record = ConsentRecord(subject=subject, token=token, metadata=dict(metadata or {}))
+        self._records[subject] = record
+        return record
+
+    def get(self, subject: str) -> ConsentRecord | None:
+        return self._records.get(subject)
+
+    def clear(self) -> None:
+        self._records.clear()
+
+
+@dataclass
+class RevocationRecord:
+    serial: str
+    reason: str | None
+    revoked_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class CRLStore:
+    """Stores revoked certificates until a proper backing store is wired up."""
+
+    def __init__(self) -> None:
+        self._records: dict[str, RevocationRecord] = {}
+
+    def revoke(self, *, serial: str, reason: str | None) -> RevocationRecord:
+        record = RevocationRecord(serial=serial, reason=reason)
+        self._records[serial] = record
+        return record
+
+    def all_serials(self) -> list[str]:
+        return sorted(self._records)
+
+    def all_records(self) -> list[RevocationRecord]:
+        return [self._records[serial] for serial in self.all_serials()]
+
+    def clear(self) -> None:
+        self._records.clear()
+
+
+consent_registry = ConsentRegistry()
+crl_store = CRLStore()
+
+
+class TrainingOptInRequest(BaseModel):
+    subject: str = Field(..., min_length=1)
+    token: str = Field(..., min_length=1)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class TrainingOptInResponse(BaseModel):
+    status: str
+    subject: str
+    token: str
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    timestamp: datetime
+
+
+class RevokeSerialRequest(BaseModel):
+    serial: str = Field(..., min_length=1)
+    reason: str | None = None
+
+
+class CRLResponse(BaseModel):
+    serials: list[str]
+    revocations: list[RevocationRecord]
+
+
 @app.get("/health")
-def health(): return {"ok": True}
+def health():
+    return {"ok": True}
+
 
 @app.get("/live")
-def live(): return {"status": "alive"}
+def live():
+    return {"status": "alive"}
+
 
 @app.get("/ready")
-def ready(): return {"status": "ready"}
+def ready():
+    return {"status": "ready"}
 
-# Expected by smokes:
-@app.post("/consent/training/optin")
-def training_optin():
-    # TODO: persist subject/token, etc.
-    return {"status": "opted_in", "subject": None}
 
-@app.get("/crl")
+@app.post("/consent/training/optin", response_model=TrainingOptInResponse)
+def training_optin(payload: TrainingOptInRequest):
+    record = consent_registry.opt_in(
+        subject=payload.subject,
+        token=payload.token,
+        metadata=payload.metadata,
+    )
+    return TrainingOptInResponse(
+        status="opted_in",
+        subject=record.subject,
+        token=record.token,
+        metadata=record.metadata,
+        timestamp=record.timestamp,
+    )
+
+
+@app.get("/consent/training/optin/{subject}", response_model=TrainingOptInResponse)
+def get_training_optin(subject: str):
+    record = consent_registry.get(subject)
+    if record is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="subject not registered")
+    return TrainingOptInResponse(
+        status="opted_in",
+        subject=record.subject,
+        token=record.token,
+        metadata=record.metadata,
+        timestamp=record.timestamp,
+    )
+
+
+@app.post("/crl", status_code=status.HTTP_201_CREATED, response_model=RevocationRecord)
+def revoke_serial(payload: RevokeSerialRequest):
+    return crl_store.revoke(serial=payload.serial, reason=payload.reason)
+
+
+@app.get("/crl", response_model=CRLResponse)
 def crl():
-    # TODO: wire to real CRL backing store
-    return {"serials": []}
+    return CRLResponse(serials=crl_store.all_serials(), revocations=crl_store.all_records())

--- a/tests/test_consent_registry_api.py
+++ b/tests/test_consent_registry_api.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from fastapi.testclient import TestClient
+
+from services.consent_registry.app import main as consent_main
+
+
+client = TestClient(consent_main.app)
+
+
+def reset_state() -> None:
+    consent_main.consent_registry.clear()
+    consent_main.crl_store.clear()
+
+
+def test_training_optin_persists_subject_metadata() -> None:
+    reset_state()
+
+    response = client.post(
+        "/consent/training/optin",
+        json={"subject": "demo-user", "token": "dev-token", "metadata": {"cohort": "netplus"}},
+    )
+    payload = response.json()
+
+    assert response.status_code == 200
+    assert payload["status"] == "opted_in"
+    assert payload["subject"] == "demo-user"
+    assert payload["token"] == "dev-token"
+    assert payload["metadata"] == {"cohort": "netplus"}
+    # ensure ISO 8601 timestamp
+    datetime.fromisoformat(payload["timestamp"].replace("Z", "+00:00"))
+
+    follow_up = client.get("/consent/training/optin/demo-user")
+    assert follow_up.status_code == 200
+    assert follow_up.json()["token"] == "dev-token"
+
+
+def test_crl_records_revocations() -> None:
+    reset_state()
+
+    first = client.post("/crl", json={"serial": "ABC123", "reason": "test"})
+    assert first.status_code == 201
+
+    second = client.post("/crl", json={"serial": "XYZ999"})
+    assert second.status_code == 201
+
+    crl_response = client.get("/crl")
+    payload = crl_response.json()
+
+    assert crl_response.status_code == 200
+    assert payload["serials"] == ["ABC123", "XYZ999"]
+    reasons = {entry["serial"]: entry["reason"] for entry in payload["revocations"]}
+    assert reasons == {"ABC123": "test", "XYZ999": None}


### PR DESCRIPTION
## Summary
- add in-memory consent registry and CRL stores so smoke tests can persist opt-in state
- expose structured FastAPI endpoints with validation for opt-in and revocation operations
- expand pytest discovery to include the top-level tests directory and add coverage for the new API

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691616aa6f54832c9b3c3d82fcaf1e6d)