### PR TITLE
Add tenant-scoped dashboards, admin gateway, and audit-packet export

### DIFF
--- a/.github/workflows/rollup-ci.yml
+++ b/.github/workflows/rollup-ci.yml
@@ -27,3 +27,11 @@ jobs:
         run: |
           test -s services/network_overlay/policy/overlay_policy.rego
           test -s services/voice_gateway/policy/qos_policy.rego
+
+  ci-hardening:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run dashboard hardening tests
+        run: |
+          make ci-hardening

--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,11 @@ release:
 overlay-smoke:
 	bash ./scripts/smoke_overlay.sh
 
+.PHONY: ci-hardening
+ci-hardening:
+	$(call _header,CI hardening)
+	@pytest tests/test_ui_dashboards.py
+
 .PHONY: sbom
 sbom:
 	@PROJECT_NAME=arescore-foundry \

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Foundry isn’t a simulator. It’s a **parallel digital world** where FrostGate
 | DevOps | CI/CD + infra templates | GitHub Actions + Terraform |
 | Storage | Durable state & payloads | Postgres + MinIO + Elasticsearch |
 
+For a tenant-safe dashboard tour (posture, forensics, controls, admin console) and audit packet export details, see [docs/dashboards.md](docs/dashboards.md).
+
 All services are containerized and communicate via APIs or queues — no shared deps.
 
 ---

--- a/admin_gateway/__init__.py
+++ b/admin_gateway/__init__.py
@@ -1,0 +1,3 @@
+from .app import app
+
+__all__ = ["app"]

--- a/admin_gateway/app.py
+++ b/admin_gateway/app.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from typing import Optional
+import uuid
+
+from fastapi import Depends, FastAPI, Query
+
+from api.security import (
+    Principal,
+    install_request_id_middleware,
+    request_id_dependency,
+    require_csrf,
+    require_scopes,
+    require_tenant,
+)
+from api.storage import AuditEvent, DashboardStore, _now
+
+
+SCOPES = {
+    "tenant_admin": "admin:tenant",
+    "global_admin": "admin:global",
+    "audit_read": "admin:audit:read",
+    "keys_write": "admin:keys:write",
+    "quota_write": "admin:quota:write",
+}
+
+DEFAULT_STORE = DashboardStore.demo()
+
+
+def get_store() -> DashboardStore:
+    return DEFAULT_STORE
+
+
+app = FastAPI(title="Arescore Admin Gateway")
+install_request_id_middleware(app)
+
+
+def _paginate(limit: int, offset: int) -> dict:
+    return {"limit": limit, "offset": offset}
+
+
+def _log_audit_event(
+    *,
+    store: DashboardStore,
+    tenant_id: Optional[uuid.UUID],
+    actor: str,
+    action: str,
+    request_id: str,
+    metadata: Optional[dict] = None,
+) -> AuditEvent:
+    event = AuditEvent(
+        event_id=str(uuid.uuid4()),
+        tenant_id=tenant_id,
+        actor=actor,
+        action=action,
+        created_at=_now(),
+        metadata=metadata or {},
+        request_id=request_id,
+    )
+    store.audit_events.append(event)
+    return event
+
+
+@app.get("/admin/console/tenant")
+def tenant_console(
+    principal: Principal = Depends(require_tenant),
+    store: DashboardStore = Depends(get_store),
+    request_id: str = Depends(request_id_dependency),
+    _: Principal = Depends(require_scopes([SCOPES["tenant_admin"]])),
+):
+    return {
+        "request_id": request_id,
+        "tenant_id": str(principal.tenant_id),
+        "keys": [{"id": "key-01", "status": "active", "last_rotated": "2024-08-01"}],
+        "usage": {"sessions": 12, "quota": "80%"},
+    }
+
+
+@app.get("/admin/console/global")
+def global_console(
+    principal: Principal = Depends(require_scopes([SCOPES["global_admin"]])),
+    request_id: str = Depends(request_id_dependency),
+):
+    return {
+        "request_id": request_id,
+        "tenant_count": 14,
+        "regions": ["us-east", "eu-central"],
+    }
+
+
+@app.get("/admin/console/audit-log")
+def list_audit_events(
+    principal: Principal = Depends(require_tenant),
+    store: DashboardStore = Depends(get_store),
+    request_id: str = Depends(request_id_dependency),
+    _: Principal = Depends(require_scopes([SCOPES["audit_read"]])),
+    limit: int = Query(default=25, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
+):
+    tenant_events = [event for event in store.audit_events if event.tenant_id == principal.tenant_id]
+    total = len(tenant_events)
+    page = tenant_events[offset : offset + limit]
+    return {
+        "request_id": request_id,
+        "tenant_id": str(principal.tenant_id),
+        "pagination": {"total": total, **_paginate(limit, offset)},
+        "items": [
+            {
+                "event_id": event.event_id,
+                "action": event.action,
+                "actor": event.actor,
+                "created_at": event.created_at.isoformat(),
+                "metadata": event.metadata,
+                "request_id": event.request_id,
+            }
+            for event in page
+        ],
+    }
+
+
+@app.post("/admin/console/keys/rotate", dependencies=[Depends(require_csrf)])
+def rotate_keys(
+    principal: Principal = Depends(require_tenant),
+    store: DashboardStore = Depends(get_store),
+    request_id: str = Depends(request_id_dependency),
+    _: Principal = Depends(require_scopes([SCOPES["keys_write"]])),
+):
+    event = _log_audit_event(
+        store=store,
+        tenant_id=principal.tenant_id,
+        actor=principal.subject,
+        action="rotate_keys",
+        request_id=request_id,
+    )
+    return {"request_id": request_id, "status": "ok", "event_id": event.event_id}
+
+
+@app.post("/admin/console/tenants/{tenant_id}/quota", dependencies=[Depends(require_csrf)])
+def update_quota(
+    tenant_id: uuid.UUID,
+    principal: Principal = Depends(require_scopes([SCOPES["global_admin"], SCOPES["quota_write"]])),
+    store: DashboardStore = Depends(get_store),
+    request_id: str = Depends(request_id_dependency),
+):
+    event = _log_audit_event(
+        store=store,
+        tenant_id=tenant_id,
+        actor=principal.subject,
+        action="update_quota",
+        request_id=request_id,
+        metadata={"tenant_id": str(tenant_id)},
+    )
+    return {"request_id": request_id, "status": "ok", "event_id": event.event_id}

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,3 @@
+from .ui import app
+
+__all__ = ["app"]

--- a/api/security.py
+++ b/api/security.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from typing import Iterable, Optional
+
+from fastapi import Depends, Header, HTTPException, Request, status
+
+
+@dataclass(frozen=True)
+class Principal:
+    subject: str
+    tenant_id: Optional[uuid.UUID]
+    scopes: frozenset[str]
+
+    def has_scope(self, scope: str) -> bool:
+        return scope in self.scopes or "*" in self.scopes
+
+
+def _parse_scopes(raw_scopes: Optional[str]) -> frozenset[str]:
+    if not raw_scopes:
+        return frozenset()
+    scopes = [scope.strip() for scope in raw_scopes.replace(",", " ").split()]
+    return frozenset(filter(None, scopes))
+
+
+async def get_principal(
+    x_subject: Optional[str] = Header(default=None, alias="X-Subject"),
+    x_tenant_id: Optional[str] = Header(default=None, alias="X-Tenant-ID"),
+    x_scopes: Optional[str] = Header(default=None, alias="X-Scopes"),
+) -> Principal:
+    tenant_id: Optional[uuid.UUID] = None
+    if x_tenant_id:
+        try:
+            tenant_id = uuid.UUID(x_tenant_id)
+        except ValueError as exc:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid tenant header") from exc
+    return Principal(subject=x_subject or "anonymous", tenant_id=tenant_id, scopes=_parse_scopes(x_scopes))
+
+
+def require_tenant(principal: Principal = Depends(get_principal)) -> Principal:
+    if principal.tenant_id is None:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Tenant-scoped identity required")
+    return principal
+
+
+def require_scopes(required: Iterable[str]):
+    required_set = tuple(required)
+
+    def _check(principal: Principal = Depends(get_principal)) -> Principal:
+        missing = [scope for scope in required_set if not principal.has_scope(scope)]
+        if missing:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"Missing required scope(s): {', '.join(missing)}",
+            )
+        return principal
+
+    return _check
+
+
+def require_csrf(request: Request, x_csrf_token: Optional[str] = Header(default=None, alias="X-CSRF-Token")) -> None:
+    if request.method in {"POST", "PUT", "PATCH", "DELETE"} and not x_csrf_token:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Missing CSRF token")
+
+
+async def request_id_dependency(request: Request) -> str:
+    return request.state.request_id
+
+
+def install_request_id_middleware(app) -> None:
+    @app.middleware("http")
+    async def request_id_middleware(request: Request, call_next):  # type: ignore[no-untyped-def]
+        request_id = request.headers.get("X-Request-ID") or str(uuid.uuid4())
+        request.state.request_id = request_id
+        response = await call_next(request)
+        response.headers["X-Request-ID"] = request_id
+        return response

--- a/api/storage.py
+++ b/api/storage.py
@@ -1,0 +1,282 @@
+from __future__ import annotations
+
+import json
+import os
+import time
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from hashlib import sha256
+from pathlib import Path
+from typing import Iterable, Optional
+
+
+def _now() -> datetime:
+    return datetime.now(tz=timezone.utc)
+
+
+def _canonical_json(data: object) -> str:
+    return json.dumps(data, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+@dataclass
+class Decision:
+    id: str
+    tenant_id: uuid.UUID
+    created_at: datetime
+    status: str
+    policy: str
+    reason: str
+    actor: str
+    metadata: dict
+
+
+@dataclass
+class ChainRecord:
+    record_id: str
+    tenant_id: uuid.UUID
+    sequence: int
+    payload: dict
+    prev_hash: str
+    hash: str
+    created_at: datetime
+
+
+@dataclass
+class ControlInvariant:
+    id: str
+    tenant_id: uuid.UUID
+    name: str
+    status: str
+    remediation: str
+    evidence_links: list[str]
+
+
+@dataclass
+class AuditEvent:
+    event_id: str
+    tenant_id: Optional[uuid.UUID]
+    actor: str
+    action: str
+    created_at: datetime
+    metadata: dict
+    request_id: str
+
+
+@dataclass
+class DashboardStore:
+    decisions: list[Decision] = field(default_factory=list)
+    chain: list[ChainRecord] = field(default_factory=list)
+    controls: list[ControlInvariant] = field(default_factory=list)
+    audit_events: list[AuditEvent] = field(default_factory=list)
+
+    @classmethod
+    def demo(cls) -> "DashboardStore":
+        tenant_id = uuid.UUID("11111111-1111-1111-1111-111111111111")
+        decisions = [
+            Decision(
+                id="dec-001",
+                tenant_id=tenant_id,
+                created_at=_now(),
+                status="deny",
+                policy="network-egress",
+                reason="Blocked outbound to restricted ASN",
+                actor="policy-engine",
+                metadata={"severity": "high", "denies": 3},
+            ),
+            Decision(
+                id="dec-002",
+                tenant_id=tenant_id,
+                created_at=_now(),
+                status="allow",
+                policy="device-attest",
+                reason="Attestation verified",
+                actor="attestor",
+                metadata={"severity": "low", "denies": 0},
+            ),
+        ]
+        chain = build_chain(
+            tenant_id,
+            [
+                {"event": "decision", "id": "dec-001"},
+                {"event": "decision", "id": "dec-002"},
+            ],
+        )
+        controls = [
+            ControlInvariant(
+                id="inv-001",
+                tenant_id=tenant_id,
+                name="Zero-trust egress",
+                status="at_risk",
+                remediation="Rotate egress policy to least-privilege segments.",
+                evidence_links=["/ui/decision/dec-001"],
+            ),
+            ControlInvariant(
+                id="inv-002",
+                tenant_id=tenant_id,
+                name="Device attestation",
+                status="healthy",
+                remediation="Continue scheduled attestation audits.",
+                evidence_links=["/ui/decision/dec-002"],
+            ),
+        ]
+        return cls(decisions=decisions, chain=chain, controls=controls)
+
+
+def build_chain(tenant_id: uuid.UUID, payloads: Iterable[dict]) -> list[ChainRecord]:
+    chain: list[ChainRecord] = []
+    prev_hash = "genesis"
+    for idx, payload in enumerate(payloads, start=1):
+        encoded = f"{prev_hash}:{_canonical_json(payload)}"
+        digest = sha256(encoded.encode("utf-8")).hexdigest()
+        chain.append(
+            ChainRecord(
+                record_id=f"rec-{idx:03d}",
+                tenant_id=tenant_id,
+                sequence=idx,
+                payload=payload,
+                prev_hash=prev_hash,
+                hash=digest,
+                created_at=_now(),
+            )
+        )
+        prev_hash = digest
+    return chain
+
+
+def verify_chain(records: list[ChainRecord]) -> tuple[bool, Optional[ChainRecord]]:
+    prev_hash = "genesis"
+    for record in sorted(records, key=lambda item: item.sequence):
+        encoded = f"{prev_hash}:{_canonical_json(record.payload)}"
+        digest = sha256(encoded.encode("utf-8")).hexdigest()
+        if record.prev_hash != prev_hash or record.hash != digest:
+            return False, record
+        prev_hash = record.hash
+    return True, None
+
+
+def build_posture(decisions: list[Decision]) -> dict:
+    deny_count = sum(1 for decision in decisions if decision.status == "deny")
+    allow_count = sum(1 for decision in decisions if decision.status == "allow")
+    top_denies: dict[str, int] = {}
+    for decision in decisions:
+        if decision.status == "deny":
+            top_denies[decision.reason] = top_denies.get(decision.reason, 0) + 1
+    return {
+        "tiles": {
+            "allow": allow_count,
+            "deny": deny_count,
+            "total": len(decisions),
+        },
+        "trends": [
+            {"label": "last_24h", "allow": allow_count, "deny": deny_count},
+        ],
+        "top_denies": sorted(top_denies.items(), key=lambda item: item[1], reverse=True)[:5],
+    }
+
+
+def _cleanup_dir(base_dir: Path, ttl_seconds: int) -> None:
+    cutoff = time.time() - ttl_seconds
+    for child in base_dir.glob("*"):
+        if child.is_dir():
+            try:
+                if child.stat().st_mtime < cutoff:
+                    for sub in child.rglob("*"):
+                        if sub.is_file():
+                            sub.unlink(missing_ok=True)
+                    child.rmdir()
+            except OSError:
+                continue
+
+
+def build_evidence_pack(
+    *,
+    tenant_id: uuid.UUID,
+    decisions: list[Decision],
+    chain_records: list[ChainRecord],
+    base_dir: Path,
+    ttl_seconds: int = 60 * 60 * 24,
+) -> dict:
+    base_dir.mkdir(parents=True, exist_ok=True)
+    _cleanup_dir(base_dir, ttl_seconds)
+
+    verified, first_bad = verify_chain(chain_records)
+    checked_at = (
+        max((record.created_at for record in chain_records), default=_now())
+        .astimezone(timezone.utc)
+        .isoformat()
+    )
+    chain_payload = {
+        "status": "PASS" if verified else "FAIL",
+        "first_bad_record": first_bad.record_id if first_bad else None,
+        "checked_at": checked_at,
+    }
+    ordered_decisions = sorted(decisions, key=lambda item: (item.created_at, item.id))
+    decisions_jsonl = "\n".join(
+        _canonical_json(
+            {
+                "id": decision.id,
+                "tenant_id": str(decision.tenant_id),
+                "created_at": decision.created_at.astimezone(timezone.utc).isoformat(),
+                "status": decision.status,
+                "policy": decision.policy,
+                "reason": decision.reason,
+                "actor": decision.actor,
+                "metadata": decision.metadata,
+            }
+        )
+        for decision in ordered_decisions
+    ) + "\n"
+
+    sbom_path = Path("artifacts/sbom.json")
+    provenance_path = Path("artifacts/provenance.json")
+
+    manifest_files: list[Path] = []
+    bundle_root = base_dir / tenant_id.hex
+    bundle_root.mkdir(parents=True, exist_ok=True)
+
+    def write_file(rel_path: str, content: str) -> Path:
+        path = bundle_root / rel_path
+        path.write_text(content, encoding="utf-8")
+        manifest_files.append(path)
+        return path
+
+    write_file("decisions.jsonl", decisions_jsonl)
+    write_file("chain_verification.json", _canonical_json(chain_payload))
+
+    if sbom_path.exists():
+        write_file("sbom.json", sbom_path.read_text(encoding="utf-8"))
+    if provenance_path.exists():
+        write_file("provenance.json", provenance_path.read_text(encoding="utf-8"))
+
+    manifest_entries = []
+    for path in sorted(manifest_files, key=lambda item: item.name):
+        payload = path.read_bytes()
+        manifest_entries.append(
+            {
+                "file": path.name,
+                "sha256": sha256(payload).hexdigest(),
+                "bytes": len(payload),
+            }
+        )
+    manifest = {"algorithm": "sha256", "version": 1, "files": manifest_entries}
+    manifest_payload = _canonical_json(manifest)
+    manifest_path = bundle_root / "manifest.json"
+    manifest_path.write_text(manifest_payload, encoding="utf-8")
+
+    token = sha256(manifest_payload.encode("utf-8")).hexdigest()
+    token_path = base_dir / token
+    if token_path.exists():
+        for sub in bundle_root.rglob("*"):
+            if sub.is_file():
+                sub.unlink(missing_ok=True)
+        bundle_root.rmdir()
+    else:
+        bundle_root.rename(token_path)
+
+    return {
+        "token": token,
+        "path": str(token_path),
+        "manifest": manifest,
+        "chain_verification": chain_payload,
+    }

--- a/api/ui.py
+++ b/api/ui.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+import os
+import uuid
+
+from fastapi import Depends, FastAPI, HTTPException, Query, status
+
+from api.security import (
+    Principal,
+    install_request_id_middleware,
+    request_id_dependency,
+    require_scopes,
+    require_tenant,
+)
+from api.storage import DashboardStore, build_evidence_pack, build_posture, verify_chain
+
+
+SCOPES = {
+    "posture_read": "ui:posture:read",
+    "decisions_read": "ui:decisions:read",
+    "forensics_read": "ui:forensics:read",
+    "controls_read": "ui:controls:read",
+    "audit_export": "ui:audit:export",
+}
+
+DEFAULT_STORE = DashboardStore.demo()
+
+
+def get_store() -> DashboardStore:
+    return DEFAULT_STORE
+
+
+app = FastAPI(title="Arescore UI API")
+install_request_id_middleware(app)
+
+
+def _paginate(limit: int, offset: int) -> dict:
+    return {"limit": limit, "offset": offset}
+
+
+@app.get("/ui/posture")
+def posture_dashboard(
+    principal: Principal = Depends(require_tenant),
+    store: DashboardStore = Depends(get_store),
+    request_id: str = Depends(request_id_dependency),
+    _: Principal = Depends(require_scopes([SCOPES["posture_read"]])),
+):
+    tenant_decisions = [decision for decision in store.decisions if decision.tenant_id == principal.tenant_id]
+    return {"request_id": request_id, "tenant_id": str(principal.tenant_id), "posture": build_posture(tenant_decisions)}
+
+
+@app.get("/ui/decisions")
+def list_decisions(
+    principal: Principal = Depends(require_tenant),
+    store: DashboardStore = Depends(get_store),
+    request_id: str = Depends(request_id_dependency),
+    _: Principal = Depends(require_scopes([SCOPES["decisions_read"]])),
+    status_filter: Optional[str] = Query(default=None, alias="status"),
+    policy_filter: Optional[str] = Query(default=None, alias="policy"),
+    limit: int = Query(default=25, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
+):
+    tenant_decisions = [decision for decision in store.decisions if decision.tenant_id == principal.tenant_id]
+    if status_filter:
+        tenant_decisions = [decision for decision in tenant_decisions if decision.status == status_filter]
+    if policy_filter:
+        tenant_decisions = [decision for decision in tenant_decisions if decision.policy == policy_filter]
+    total = len(tenant_decisions)
+    page = tenant_decisions[offset : offset + limit]
+    return {
+        "request_id": request_id,
+        "tenant_id": str(principal.tenant_id),
+        "pagination": {"total": total, **_paginate(limit, offset)},
+        "items": [
+            {
+                "id": decision.id,
+                "created_at": decision.created_at.isoformat(),
+                "status": decision.status,
+                "policy": decision.policy,
+                "reason": decision.reason,
+                "actor": decision.actor,
+                "metadata": decision.metadata,
+            }
+            for decision in page
+        ],
+    }
+
+
+@app.get("/ui/decision/{decision_id}")
+def get_decision(
+    decision_id: str,
+    principal: Principal = Depends(require_tenant),
+    store: DashboardStore = Depends(get_store),
+    request_id: str = Depends(request_id_dependency),
+    _: Principal = Depends(require_scopes([SCOPES["decisions_read"]])),
+):
+    for decision in store.decisions:
+        if decision.id == decision_id and decision.tenant_id == principal.tenant_id:
+            return {
+                "request_id": request_id,
+                "tenant_id": str(principal.tenant_id),
+                "decision": {
+                    "id": decision.id,
+                    "created_at": decision.created_at.isoformat(),
+                    "status": decision.status,
+                    "policy": decision.policy,
+                    "reason": decision.reason,
+                    "actor": decision.actor,
+                    "metadata": decision.metadata,
+                },
+            }
+    raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Decision not found")
+
+
+@app.get("/ui/forensics/chain/verify")
+def verify_forensics_chain(
+    principal: Principal = Depends(require_tenant),
+    store: DashboardStore = Depends(get_store),
+    request_id: str = Depends(request_id_dependency),
+    _: Principal = Depends(require_scopes([SCOPES["forensics_read"]])),
+):
+    tenant_chain = [record for record in store.chain if record.tenant_id == principal.tenant_id]
+    verified, first_bad = verify_chain(tenant_chain)
+    return {
+        "request_id": request_id,
+        "tenant_id": str(principal.tenant_id),
+        "status": "PASS" if verified else "FAIL",
+        "first_bad_record": first_bad.record_id if first_bad else None,
+    }
+
+
+@app.post("/ui/audit/packet")
+def create_audit_packet(
+    principal: Principal = Depends(require_tenant),
+    store: DashboardStore = Depends(get_store),
+    request_id: str = Depends(request_id_dependency),
+    _: Principal = Depends(require_scopes([SCOPES["audit_export"]])),
+):
+    tenant_decisions = [decision for decision in store.decisions if decision.tenant_id == principal.tenant_id]
+    tenant_chain = [record for record in store.chain if record.tenant_id == principal.tenant_id]
+    base_dir = Path(os.getenv("UI_PACKETS_DIR", "artifacts/ui_packets"))
+    pack = build_evidence_pack(
+        tenant_id=principal.tenant_id,
+        decisions=tenant_decisions,
+        chain_records=tenant_chain,
+        base_dir=base_dir,
+    )
+    return {
+        "request_id": request_id,
+        "tenant_id": str(principal.tenant_id),
+        "token": pack["token"],
+        "path": pack["path"],
+        "manifest": pack["manifest"],
+        "chain_verification": pack["chain_verification"],
+    }
+
+
+@app.get("/ui/controls")
+def list_controls(
+    principal: Principal = Depends(require_tenant),
+    store: DashboardStore = Depends(get_store),
+    request_id: str = Depends(request_id_dependency),
+    _: Principal = Depends(require_scopes([SCOPES["controls_read"]])),
+    limit: int = Query(default=25, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
+):
+    tenant_controls = [control for control in store.controls if control.tenant_id == principal.tenant_id]
+    total = len(tenant_controls)
+    page = tenant_controls[offset : offset + limit]
+    return {
+        "request_id": request_id,
+        "tenant_id": str(principal.tenant_id),
+        "pagination": {"total": total, **_paginate(limit, offset)},
+        "items": [
+            {
+                "id": control.id,
+                "name": control.name,
+                "status": control.status,
+                "evidence_links": control.evidence_links,
+                "remediation": control.remediation,
+            }
+            for control in page
+        ],
+    }
+
+
+@app.get("/ui/controls/{inv_id}")
+def get_control(
+    inv_id: str,
+    principal: Principal = Depends(require_tenant),
+    store: DashboardStore = Depends(get_store),
+    request_id: str = Depends(request_id_dependency),
+    _: Principal = Depends(require_scopes([SCOPES["controls_read"]])),
+):
+    for control in store.controls:
+        if control.id == inv_id and control.tenant_id == principal.tenant_id:
+            return {
+                "request_id": request_id,
+                "tenant_id": str(principal.tenant_id),
+                "control": {
+                    "id": control.id,
+                    "name": control.name,
+                    "status": control.status,
+                    "evidence_links": control.evidence_links,
+                    "remediation": control.remediation,
+                },
+            }
+    raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Control not found")

--- a/docs/dashboards.md
+++ b/docs/dashboards.md
@@ -1,0 +1,18 @@
+# Dashboard & Audit Packet Overview
+
+## Tenant dashboards
+- **Security Posture**: posture tiles, denial trends, and top deny drivers are available via tenant-scoped endpoints (`/ui/posture`, `/ui/decisions`). Each request requires tenant binding and UI scopes.
+- **Evidence & Forensics**: chain-of-custody verification is surfaced via `/ui/forensics/chain/verify` with PASS/FAIL and first-bad-record reporting.
+- **Controls & Remediation**: invariant proof matrix data is exposed via `/ui/controls` and `/ui/controls/{inv_id}` with evidence links and remediation guidance.
+
+## Admin console
+- **Tenant admin** and **global admin** dashboard paths return key, usage, quota, and audit log summaries.
+- State-changing actions (key rotation and quota updates) emit structured audit events with request correlation IDs.
+
+## Audit packet export
+- The export endpoint (`POST /ui/audit/packet`) builds a deterministic evidence bundle containing:
+  - `decisions.jsonl` (canonicalized decision list)
+  - `chain_verification.json` (PASS/FAIL status + first bad record)
+  - `manifest.json` (sha256 hashes and file sizes)
+  - Optional `sbom.json` and `provenance.json` when present
+- Bundles are stored in a temporary artifacts directory with TTL cleanup.

--- a/frontend/app/(app)/admin/admin-actions.tsx
+++ b/frontend/app/(app)/admin/admin-actions.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+const ADMIN_API_BASE = process.env.NEXT_PUBLIC_ADMIN_API_BASE ?? "http://localhost:8091";
+const DEFAULT_TENANT_ID = process.env.NEXT_PUBLIC_TENANT_ID ?? "11111111-1111-1111-1111-111111111111";
+
+export function AdminActions() {
+  const [message, setMessage] = useState<string | null>(null);
+
+  async function rotateKeys() {
+    setMessage(null);
+    const response = await fetch(`${ADMIN_API_BASE}/admin/console/keys/rotate`, {
+      method: "POST",
+      headers: {
+        "X-Tenant-ID": DEFAULT_TENANT_ID,
+        "X-Scopes": "admin:keys:write admin:tenant",
+        "X-Subject": "admin-demo",
+        "X-Request-ID": "admin-rotate",
+        "X-CSRF-Token": "admin-demo-csrf",
+      },
+    });
+    setMessage(response.ok ? "Keys rotated and audit event recorded." : "Failed to rotate keys.");
+  }
+
+  async function updateQuota() {
+    setMessage(null);
+    const response = await fetch(`${ADMIN_API_BASE}/admin/console/tenants/${DEFAULT_TENANT_ID}/quota`, {
+      method: "POST",
+      headers: {
+        "X-Scopes": "admin:global admin:quota:write",
+        "X-Subject": "admin-demo",
+        "X-Request-ID": "admin-quota",
+        "X-CSRF-Token": "admin-demo-csrf",
+      },
+    });
+    setMessage(response.ok ? "Quota updated and audit event recorded." : "Failed to update quota.");
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Admin Actions</CardTitle>
+        <CardDescription>State-changing actions recorded with structured audit events.</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="flex flex-wrap gap-3">
+          <Button onClick={rotateKeys}>Rotate keys</Button>
+          <Button variant="outline" onClick={updateQuota}>
+            Update quota
+          </Button>
+        </div>
+        {message && <p className="text-sm text-muted-foreground">{message}</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/app/(app)/admin/page.tsx
+++ b/frontend/app/(app)/admin/page.tsx
@@ -1,6 +1,7 @@
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
+import { BrandHeader } from "@/components/layout/brand-header";
 import { fetchAdmin } from "@/lib/admin-api";
 import { AdminActions } from "./admin-actions";
 
@@ -37,6 +38,10 @@ export default async function AdminPage() {
 
   return (
     <div className="space-y-6">
+      <BrandHeader
+        title="Admin Console"
+        subtitle="Frostgate admin operations with tenant and global oversight."
+      />
       <Card>
         <CardHeader>
           <CardTitle>Admin Console</CardTitle>

--- a/frontend/app/(app)/admin/page.tsx
+++ b/frontend/app/(app)/admin/page.tsx
@@ -1,0 +1,98 @@
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import { fetchAdmin } from "@/lib/admin-api";
+import { AdminActions } from "./admin-actions";
+
+type TenantConsole = {
+  keys: Array<{ id: string; status: string; last_rotated: string }>;
+  usage: { sessions: number; quota: string };
+};
+
+type GlobalConsole = {
+  tenant_count: number;
+  regions: string[];
+};
+
+type AuditLog = {
+  items: Array<{ event_id: string; action: string; actor: string; created_at: string }>;
+};
+
+const fallbackTenant: TenantConsole = { keys: [], usage: { sessions: 0, quota: "0%" } };
+const fallbackGlobal: GlobalConsole = { tenant_count: 0, regions: [] };
+const fallbackAudit: AuditLog = { items: [] };
+
+export default async function AdminPage() {
+  let tenantConsole = fallbackTenant;
+  let globalConsole = fallbackGlobal;
+  let auditLog = fallbackAudit;
+
+  try {
+    tenantConsole = await fetchAdmin<TenantConsole>("/admin/console/tenant", { scopes: ["admin:tenant"] });
+    globalConsole = await fetchAdmin<GlobalConsole>("/admin/console/global", { scopes: ["admin:global"] });
+    auditLog = await fetchAdmin<AuditLog>("/admin/console/audit-log?limit=5", { scopes: ["admin:audit:read"] });
+  } catch {
+    // fallback in non-connected environments.
+  }
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Admin Console</CardTitle>
+          <CardDescription>Tenant and global admin visibility with audit trails.</CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-6 lg:grid-cols-2">
+          <div className="space-y-3 rounded-xl border border-border/60 bg-background/60 p-4">
+            <p className="text-xs uppercase tracking-wider text-muted-foreground">Tenant overview</p>
+            <div className="flex items-center justify-between text-sm">
+              <span>Active keys</span>
+              <Badge variant="outline">{tenantConsole.keys.length}</Badge>
+            </div>
+            <div className="flex items-center justify-between text-sm">
+              <span>Sessions</span>
+              <Badge variant="outline">{tenantConsole.usage.sessions}</Badge>
+            </div>
+            <div className="flex items-center justify-between text-sm">
+              <span>Quota usage</span>
+              <Badge variant="outline">{tenantConsole.usage.quota}</Badge>
+            </div>
+          </div>
+          <div className="space-y-3 rounded-xl border border-border/60 bg-background/60 p-4">
+            <p className="text-xs uppercase tracking-wider text-muted-foreground">Global oversight</p>
+            <div className="flex items-center justify-between text-sm">
+              <span>Tenants</span>
+              <Badge variant="outline">{globalConsole.tenant_count}</Badge>
+            </div>
+            <div className="flex items-center justify-between text-sm">
+              <span>Regions</span>
+              <Badge variant="outline">{globalConsole.regions.join(", ") || "none"}</Badge>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <AdminActions />
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Audit Log</CardTitle>
+          <CardDescription>Recent admin events for this tenant.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {auditLog.items.length === 0 && <p className="text-sm text-muted-foreground">No audit events yet.</p>}
+          {auditLog.items.map((event) => (
+            <div key={event.event_id} className="rounded-xl border border-border/60 bg-background/60 p-3">
+              <div className="flex items-center justify-between text-sm">
+                <span className="font-semibold">{event.action}</span>
+                <Badge variant="outline">{event.actor}</Badge>
+              </div>
+              <Separator className="my-2" />
+              <p className="text-xs text-muted-foreground">{event.created_at}</p>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/app/(app)/controls/[id]/page.tsx
+++ b/frontend/app/(app)/controls/[id]/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { BrandHeader } from "@/components/layout/brand-header";
 import { fetchUi } from "@/lib/ui-api";
 
 type ControlResponse = {
@@ -33,31 +34,37 @@ export default async function ControlDetailPage({ params }: { params: { id: stri
   }
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>{control.control.name}</CardTitle>
-        <CardDescription>Evidence links and remediation guidance.</CardDescription>
-      </CardHeader>
-      <CardContent className="space-y-4">
-        <Badge variant={control.control.status === "healthy" ? "default" : "outline"}>
-          {control.control.status}
-        </Badge>
-        <p className="text-sm text-muted-foreground">{control.control.remediation}</p>
-        <div className="space-y-2">
-          <p className="text-xs uppercase tracking-wider text-muted-foreground">Evidence Links</p>
-          {control.control.evidence_links.length === 0 && (
-            <p className="text-sm text-muted-foreground">No evidence linked.</p>
-          )}
-          {control.control.evidence_links.map((link) => (
-            <Link key={link} href={link} className="block text-sm text-accent hover:underline">
-              {link}
-            </Link>
-          ))}
-        </div>
-        <Link href="/controls" className="text-sm text-muted-foreground hover:text-foreground">
-          ← Back to controls
-        </Link>
-      </CardContent>
-    </Card>
+    <div className="space-y-6">
+      <BrandHeader
+        title="Control Detail"
+        subtitle="Frostgate control evidence and remediation steps."
+      />
+      <Card>
+        <CardHeader>
+          <CardTitle>{control.control.name}</CardTitle>
+          <CardDescription>Evidence links and remediation guidance.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Badge variant={control.control.status === "healthy" ? "default" : "outline"}>
+            {control.control.status}
+          </Badge>
+          <p className="text-sm text-muted-foreground">{control.control.remediation}</p>
+          <div className="space-y-2">
+            <p className="text-xs uppercase tracking-wider text-muted-foreground">Evidence Links</p>
+            {control.control.evidence_links.length === 0 && (
+              <p className="text-sm text-muted-foreground">No evidence linked.</p>
+            )}
+            {control.control.evidence_links.map((link) => (
+              <Link key={link} href={link} className="block text-sm text-accent hover:underline">
+                {link}
+              </Link>
+            ))}
+          </div>
+          <Link href="/controls" className="text-sm text-muted-foreground hover:text-foreground">
+            ← Back to controls
+          </Link>
+        </CardContent>
+      </Card>
+    </div>
   );
 }

--- a/frontend/app/(app)/controls/[id]/page.tsx
+++ b/frontend/app/(app)/controls/[id]/page.tsx
@@ -1,0 +1,63 @@
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { fetchUi } from "@/lib/ui-api";
+
+type ControlResponse = {
+  control: {
+    id: string;
+    name: string;
+    status: string;
+    remediation: string;
+    evidence_links: string[];
+  };
+};
+
+const fallbackControl: ControlResponse = {
+  control: {
+    id: "",
+    name: "Unknown control",
+    status: "unknown",
+    remediation: "No remediation available.",
+    evidence_links: [],
+  },
+};
+
+export default async function ControlDetailPage({ params }: { params: { id: string } }) {
+  let control = fallbackControl;
+
+  try {
+    control = await fetchUi<ControlResponse>(`/ui/controls/${params.id}`, { scopes: ["ui:controls:read"] });
+  } catch {
+    // fallback in non-connected environments.
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{control.control.name}</CardTitle>
+        <CardDescription>Evidence links and remediation guidance.</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <Badge variant={control.control.status === "healthy" ? "default" : "outline"}>
+          {control.control.status}
+        </Badge>
+        <p className="text-sm text-muted-foreground">{control.control.remediation}</p>
+        <div className="space-y-2">
+          <p className="text-xs uppercase tracking-wider text-muted-foreground">Evidence Links</p>
+          {control.control.evidence_links.length === 0 && (
+            <p className="text-sm text-muted-foreground">No evidence linked.</p>
+          )}
+          {control.control.evidence_links.map((link) => (
+            <Link key={link} href={link} className="block text-sm text-accent hover:underline">
+              {link}
+            </Link>
+          ))}
+        </div>
+        <Link href="/controls" className="text-sm text-muted-foreground hover:text-foreground">
+          ← Back to controls
+        </Link>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/app/(app)/controls/page.tsx
+++ b/frontend/app/(app)/controls/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { BrandHeader } from "@/components/layout/brand-header";
 import { fetchUi } from "@/lib/ui-api";
 
 type ControlsResponse = {
@@ -24,29 +25,35 @@ export default async function ControlsPage() {
   }
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Controls &amp; Remediation</CardTitle>
-        <CardDescription>Invariant proof matrix mapped to evidence and remediation.</CardDescription>
-      </CardHeader>
-      <CardContent className="space-y-4">
-        {controls.items.length === 0 && <p className="text-sm text-muted-foreground">No controls available.</p>}
-        {controls.items.map((control) => (
-          <Link
-            key={control.id}
-            href={`/controls/${control.id}`}
-            className="block rounded-xl border border-border/60 bg-background/60 p-4 transition hover:border-accent/60 hover:bg-foreground/5"
-          >
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="font-semibold">{control.name}</p>
-                <p className="text-xs text-muted-foreground">{control.remediation}</p>
+    <div className="space-y-6">
+      <BrandHeader
+        title="Controls & Remediation"
+        subtitle="Frostgate invariants mapped to evidence and guided remediation."
+      />
+      <Card>
+        <CardHeader>
+          <CardTitle>Controls &amp; Remediation</CardTitle>
+          <CardDescription>Invariant proof matrix mapped to evidence and remediation.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {controls.items.length === 0 && <p className="text-sm text-muted-foreground">No controls available.</p>}
+          {controls.items.map((control) => (
+            <Link
+              key={control.id}
+              href={`/controls/${control.id}`}
+              className="block rounded-xl border border-border/60 bg-background/60 p-4 transition hover:border-accent/60 hover:bg-foreground/5"
+            >
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="font-semibold">{control.name}</p>
+                  <p className="text-xs text-muted-foreground">{control.remediation}</p>
+                </div>
+                <Badge variant={control.status === "healthy" ? "default" : "outline"}>{control.status}</Badge>
               </div>
-              <Badge variant={control.status === "healthy" ? "default" : "outline"}>{control.status}</Badge>
-            </div>
-          </Link>
-        ))}
-      </CardContent>
-    </Card>
+            </Link>
+          ))}
+        </CardContent>
+      </Card>
+    </div>
   );
 }

--- a/frontend/app/(app)/controls/page.tsx
+++ b/frontend/app/(app)/controls/page.tsx
@@ -1,0 +1,52 @@
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { fetchUi } from "@/lib/ui-api";
+
+type ControlsResponse = {
+  items: Array<{
+    id: string;
+    name: string;
+    status: string;
+    remediation: string;
+  }>;
+};
+
+const fallbackControls: ControlsResponse = { items: [] };
+
+export default async function ControlsPage() {
+  let controls = fallbackControls;
+
+  try {
+    controls = await fetchUi<ControlsResponse>("/ui/controls?limit=10", { scopes: ["ui:controls:read"] });
+  } catch {
+    // fallback in non-connected environments.
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Controls &amp; Remediation</CardTitle>
+        <CardDescription>Invariant proof matrix mapped to evidence and remediation.</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {controls.items.length === 0 && <p className="text-sm text-muted-foreground">No controls available.</p>}
+        {controls.items.map((control) => (
+          <Link
+            key={control.id}
+            href={`/controls/${control.id}`}
+            className="block rounded-xl border border-border/60 bg-background/60 p-4 transition hover:border-accent/60 hover:bg-foreground/5"
+          >
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="font-semibold">{control.name}</p>
+                <p className="text-xs text-muted-foreground">{control.remediation}</p>
+              </div>
+              <Badge variant={control.status === "healthy" ? "default" : "outline"}>{control.status}</Badge>
+            </div>
+          </Link>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/app/(app)/forensics/forensics-export.tsx
+++ b/frontend/app/(app)/forensics/forensics-export.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+type ExportResponse = {
+  token: string;
+  path: string;
+};
+
+const UI_API_BASE = process.env.NEXT_PUBLIC_UI_API_BASE ?? "http://localhost:8090";
+const DEFAULT_TENANT_ID = process.env.NEXT_PUBLIC_TENANT_ID ?? "11111111-1111-1111-1111-111111111111";
+
+export function ForensicsExport() {
+  const [status, setStatus] = useState<"idle" | "loading" | "done" | "error">("idle");
+  const [result, setResult] = useState<ExportResponse | null>(null);
+
+  async function handleExport() {
+    setStatus("loading");
+    setResult(null);
+
+    try {
+      const response = await fetch(`${UI_API_BASE}/ui/audit/packet`, {
+        method: "POST",
+        headers: {
+          "X-Tenant-ID": DEFAULT_TENANT_ID,
+          "X-Scopes": "ui:audit:export",
+          "X-Subject": "ui-demo",
+          "X-Request-ID": "ui-demo-export",
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error("Export failed");
+      }
+
+      const payload = (await response.json()) as ExportResponse;
+      setResult({ token: payload.token, path: payload.path });
+      setStatus("done");
+    } catch {
+      setStatus("error");
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Audit Packet Export</CardTitle>
+        <CardDescription>Bundle evidence, chain verification, and manifest hashes.</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <Button onClick={handleExport} disabled={status === "loading"}>
+          {status === "loading" ? "Building packet..." : "Export audit packet"}
+        </Button>
+        {status === "error" && <p className="text-sm text-destructive">Unable to export audit packet.</p>}
+        {result && (
+          <div className="rounded-xl border border-border/60 bg-background/60 p-3 text-xs text-muted-foreground">
+            <p>
+              <span className="font-semibold text-foreground">Token:</span> {result.token}
+            </p>
+            <p>
+              <span className="font-semibold text-foreground">Path:</span> {result.path}
+            </p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/app/(app)/forensics/page.tsx
+++ b/frontend/app/(app)/forensics/page.tsx
@@ -1,6 +1,7 @@
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
+import { BrandHeader } from "@/components/layout/brand-header";
 import { fetchUi } from "@/lib/ui-api";
 import { ForensicsExport } from "./forensics-export";
 
@@ -24,6 +25,10 @@ export default async function ForensicsPage() {
 
   return (
     <div className="space-y-6">
+      <BrandHeader
+        title="Evidence & Forensics"
+        subtitle="Frostgate chain-of-custody verification and forensic readiness."
+      />
       <Card>
         <CardHeader>
           <CardTitle>Evidence &amp; Forensics</CardTitle>

--- a/frontend/app/(app)/forensics/page.tsx
+++ b/frontend/app/(app)/forensics/page.tsx
@@ -1,0 +1,56 @@
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import { fetchUi } from "@/lib/ui-api";
+import { ForensicsExport } from "./forensics-export";
+
+type ChainVerifyResponse = {
+  status: "PASS" | "FAIL";
+  first_bad_record: string | null;
+};
+
+const fallbackVerify: ChainVerifyResponse = { status: "FAIL", first_bad_record: null };
+
+export default async function ForensicsPage() {
+  let verification = fallbackVerify;
+
+  try {
+    verification = await fetchUi<ChainVerifyResponse>("/ui/forensics/chain/verify", {
+      scopes: ["ui:forensics:read"],
+    });
+  } catch {
+    // use fallback in non-connected environments.
+  }
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Evidence &amp; Forensics</CardTitle>
+          <CardDescription>Chain-of-custody verification and forensic readiness.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex items-center justify-between rounded-xl border border-border/60 bg-background/60 p-4">
+            <div>
+              <p className="text-sm font-semibold">Chain Verification</p>
+              <p className="text-xs text-muted-foreground">Detect tampering in audit records.</p>
+            </div>
+            <Badge variant={verification.status === "PASS" ? "default" : "destructive"}>
+              {verification.status}
+            </Badge>
+          </div>
+          {verification.first_bad_record && (
+            <>
+              <Separator />
+              <p className="text-sm text-muted-foreground">
+                First bad record: <span className="font-semibold text-foreground">{verification.first_bad_record}</span>
+              </p>
+            </>
+          )}
+        </CardContent>
+      </Card>
+
+      <ForensicsExport />
+    </div>
+  );
+}

--- a/frontend/app/(app)/posture/page.tsx
+++ b/frontend/app/(app)/posture/page.tsx
@@ -1,6 +1,7 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
+import { BrandHeader } from "@/components/layout/brand-header";
 import { fetchUi } from "@/lib/ui-api";
 
 type PostureResponse = {
@@ -44,6 +45,10 @@ export default async function PosturePage() {
 
   return (
     <div className="space-y-6">
+      <BrandHeader
+        title="Security Posture"
+        subtitle="Frostgate-aligned posture tiles, denial trends, and enforcement insights."
+      />
       <Card>
         <CardHeader>
           <CardTitle>Security Posture</CardTitle>

--- a/frontend/app/(app)/posture/page.tsx
+++ b/frontend/app/(app)/posture/page.tsx
@@ -1,0 +1,109 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Separator } from "@/components/ui/separator";
+import { fetchUi } from "@/lib/ui-api";
+
+type PostureResponse = {
+  posture: {
+    tiles: { allow: number; deny: number; total: number };
+    trends: Array<{ label: string; allow: number; deny: number }>;
+    top_denies: Array<[string, number]>;
+  };
+};
+
+type DecisionResponse = {
+  items: Array<{
+    id: string;
+    created_at: string;
+    status: string;
+    policy: string;
+    reason: string;
+  }>;
+};
+
+const fallbackPosture: PostureResponse = {
+  posture: {
+    tiles: { allow: 0, deny: 0, total: 0 },
+    trends: [{ label: "last_24h", allow: 0, deny: 0 }],
+    top_denies: [],
+  },
+};
+
+const fallbackDecisions: DecisionResponse = { items: [] };
+
+export default async function PosturePage() {
+  let posture = fallbackPosture;
+  let decisions = fallbackDecisions;
+
+  try {
+    posture = await fetchUi<PostureResponse>("/ui/posture", { scopes: ["ui:posture:read"] });
+    decisions = await fetchUi<DecisionResponse>("/ui/decisions?limit=5", { scopes: ["ui:decisions:read"] });
+  } catch {
+    // Fall back to empty state in non-connected environments.
+  }
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Security Posture</CardTitle>
+          <CardDescription>Tenant-scoped allow/deny posture with top denial drivers.</CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-4 md:grid-cols-3">
+          <div className="rounded-xl border border-border/60 bg-background/60 p-4">
+            <p className="text-xs uppercase tracking-wider text-muted-foreground">Allow</p>
+            <p className="text-2xl font-semibold">{posture.posture.tiles.allow}</p>
+          </div>
+          <div className="rounded-xl border border-border/60 bg-background/60 p-4">
+            <p className="text-xs uppercase tracking-wider text-muted-foreground">Deny</p>
+            <p className="text-2xl font-semibold">{posture.posture.tiles.deny}</p>
+          </div>
+          <div className="rounded-xl border border-border/60 bg-background/60 p-4">
+            <p className="text-xs uppercase tracking-wider text-muted-foreground">Total</p>
+            <p className="text-2xl font-semibold">{posture.posture.tiles.total}</p>
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle>Denial Drivers</CardTitle>
+            <CardDescription>Top reasons for policy denials.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {posture.posture.top_denies.length === 0 && (
+              <p className="text-sm text-muted-foreground">No denials recorded.</p>
+            )}
+            {posture.posture.top_denies.map(([reason, count]) => (
+              <div key={reason} className="flex items-center justify-between text-sm">
+                <span className="text-muted-foreground">{reason}</span>
+                <Badge variant="outline">{count}</Badge>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>Recent Decisions</CardTitle>
+            <CardDescription>Latest enforcement decisions for this tenant.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {decisions.items.length === 0 && <p className="text-sm text-muted-foreground">No decisions found.</p>}
+            {decisions.items.map((decision) => (
+              <div key={decision.id} className="space-y-1 rounded-xl border border-border/60 p-3">
+                <div className="flex items-center justify-between text-sm">
+                  <span className="font-semibold">{decision.policy}</span>
+                  <Badge variant={decision.status === "deny" ? "destructive" : "default"}>{decision.status}</Badge>
+                </div>
+                <p className="text-xs text-muted-foreground">{decision.reason}</p>
+                <Separator className="my-2" />
+                <p className="text-[11px] uppercase tracking-wider text-muted-foreground">{decision.created_at}</p>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -3,43 +3,43 @@
 @tailwind utilities;
 
 :root {
-  --background: 224 60% 6%;
-  --foreground: 214 40% 96%;
-  --muted: 222 35% 18%;
-  --muted-foreground: 214 20% 70%;
-  --accent: 198 67% 48%;
-  --accent-foreground: 214 40% 98%;
-  --primary: 199 80% 64%;
-  --primary-foreground: 222 35% 16%;
-  --secondary: 262 65% 64%;
-  --secondary-foreground: 214 40% 98%;
+  --background: 222 32% 7%;
+  --foreground: 210 20% 96%;
+  --muted: 218 30% 16%;
+  --muted-foreground: 210 12% 72%;
+  --accent: 210 55% 42%;
+  --accent-foreground: 210 20% 96%;
+  --primary: 210 55% 48%;
+  --primary-foreground: 220 20% 96%;
+  --secondary: 20 62% 45%;
+  --secondary-foreground: 210 20% 96%;
   --success: 152 65% 46%;
   --success-foreground: 224 60% 6%;
-  --warning: 35 93% 53%;
-  --warning-foreground: 224 60% 6%;
-  --destructive: 353 84% 48%;
+  --warning: 28 85% 48%;
+  --warning-foreground: 220 20% 96%;
+  --destructive: 4 70% 45%;
   --destructive-foreground: 214 40% 98%;
-  --border: 224 36% 24%;
-  --input: 224 36% 24%;
-  --ring: 198 67% 48%;
+  --border: 220 24% 22%;
+  --input: 220 24% 22%;
+  --ring: 20 62% 45%;
   --radius: 14px;
 }
 
 [data-theme="cinder"] {
-  --background: 226 53% 5%;
-  --foreground: 210 50% 96%;
-  --accent: 190 75% 54%;
-  --accent-foreground: 210 60% 98%;
-  --primary: 192 82% 58%;
-  --primary-foreground: 219 37% 12%;
-  --secondary: 272 61% 66%;
-  --secondary-foreground: 213 43% 96%;
+  --background: 222 35% 5%;
+  --foreground: 210 22% 96%;
+  --accent: 210 60% 44%;
+  --accent-foreground: 210 20% 96%;
+  --primary: 210 58% 50%;
+  --primary-foreground: 220 22% 96%;
+  --secondary: 20 65% 46%;
+  --secondary-foreground: 210 22% 96%;
 }
 
 body {
   min-height: 100vh;
-  background: radial-gradient(circle at top, hsla(199, 80%, 14%, 0.35), transparent 55%),
-    radial-gradient(circle at bottom, hsla(262, 65%, 12%, 0.4), transparent 60%),
+  background: radial-gradient(circle at top, hsla(210, 55%, 24%, 0.4), transparent 55%),
+    radial-gradient(circle at bottom, hsla(20, 62%, 24%, 0.35), transparent 60%),
     hsl(var(--background));
   color: hsl(var(--foreground));
   font-feature-settings: "ss01" on, "cv11" on;
@@ -47,14 +47,21 @@ body {
 }
 
 .rune-grid {
-  background-image: linear-gradient(90deg, hsla(214, 40%, 98%, 0.04) 1px, transparent 1px),
-    linear-gradient(0deg, hsla(214, 40%, 98%, 0.04) 1px, transparent 1px);
+  background-image: linear-gradient(90deg, hsla(210, 20%, 96%, 0.04) 1px, transparent 1px),
+    linear-gradient(0deg, hsla(210, 20%, 96%, 0.04) 1px, transparent 1px);
   background-size: 40px 40px;
 }
 
 .rune-highlight {
-  background: linear-gradient(135deg, hsla(198, 67%, 48%, 0.3), hsla(262, 65%, 46%, 0.35));
-  box-shadow: 0 20px 50px -30px hsla(199, 80%, 46%, 0.55);
+  background: linear-gradient(135deg, hsla(210, 55%, 42%, 0.32), hsla(20, 62%, 42%, 0.32));
+  box-shadow: 0 20px 50px -30px hsla(210, 55%, 40%, 0.5);
+}
+
+.frostgate-brand {
+  background: linear-gradient(110deg, #2a4d73 0%, #1d334d 45%, #9b4a2a 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
 }
 
 ::-webkit-scrollbar {

--- a/frontend/components/layout/brand-header.tsx
+++ b/frontend/components/layout/brand-header.tsx
@@ -1,0 +1,23 @@
+import { Badge } from "@/components/ui/badge";
+
+type BrandHeaderProps = {
+  title: string;
+  subtitle: string;
+};
+
+export function BrandHeader({ title, subtitle }: BrandHeaderProps) {
+  return (
+    <div className="rounded-2xl border border-border/60 bg-background/70 p-5 shadow-lg">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <p className="text-xs uppercase tracking-[0.4em] text-muted-foreground">Frostgate</p>
+          <h2 className="text-2xl font-semibold frostgate-brand">{title}</h2>
+          <p className="text-sm text-muted-foreground">{subtitle}</p>
+        </div>
+        <Badge variant="outline" className="border-accent/40 text-accent">
+          Frostgate Command
+        </Badge>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/navigation/runic-nav.tsx
+++ b/frontend/components/navigation/runic-nav.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn, frostgateGradient } from "@/lib/utils";
 import { navItems } from "@/lib/navigation";
-import { TenantFeatureGate } from "@/context/auth-context";
+import { TenantFeatureGate, TenantScopeGate } from "@/context/auth-context";
 
 export function RunicNav() {
   const pathname = usePathname();
@@ -14,39 +14,41 @@ export function RunicNav() {
       {navItems.map((item) => {
         const isActive = pathname?.startsWith(item.href);
         return (
-          <TenantFeatureGate key={item.name} feature={item.feature}>
-            <Link
-              href={item.href}
-              className={cn(
-                "group relative flex items-start gap-3 rounded-xl border border-border/60 bg-background/60 p-4 transition",
-                "hover:border-accent/60 hover:bg-foreground/5",
-                isActive && "border-transparent bg-gradient-to-r text-primary-foreground",
-                isActive && `from-primary/60 via-secondary/50 to-accent/60`
-              )}
-            >
-              <span
+          <TenantScopeGate key={item.name} scope={item.scope}>
+            <TenantFeatureGate feature={item.feature}>
+              <Link
+                href={item.href}
                 className={cn(
-                  "flex h-10 w-10 items-center justify-center rounded-lg border border-border/50 bg-background text-accent",
-                  "group-hover:bg-gradient-to-br group-hover:from-primary/20 group-hover:to-secondary/20"
+                  "group relative flex items-start gap-3 rounded-xl border border-border/60 bg-background/60 p-4 transition",
+                  "hover:border-accent/60 hover:bg-foreground/5",
+                  isActive && "border-transparent bg-gradient-to-r text-primary-foreground",
+                  isActive && `from-primary/60 via-secondary/50 to-accent/60`
                 )}
               >
-                <item.icon className="h-5 w-5" />
-              </span>
-              <span>
-                <p className="font-semibold text-sm">{item.name}</p>
-                <p className="text-xs text-muted-foreground">{item.description}</p>
-              </span>
-              {isActive && (
                 <span
-                  aria-hidden
                   className={cn(
-                    "absolute inset-y-0 right-0 w-1 rounded-r-xl bg-gradient-to-b",
-                    frostgateGradient
+                    "flex h-10 w-10 items-center justify-center rounded-lg border border-border/50 bg-background text-accent",
+                    "group-hover:bg-gradient-to-br group-hover:from-primary/20 group-hover:to-secondary/20"
                   )}
-                />
-              )}
-            </Link>
-          </TenantFeatureGate>
+                >
+                  <item.icon className="h-5 w-5" />
+                </span>
+                <span>
+                  <p className="font-semibold text-sm">{item.name}</p>
+                  <p className="text-xs text-muted-foreground">{item.description}</p>
+                </span>
+                {isActive && (
+                  <span
+                    aria-hidden
+                    className={cn(
+                      "absolute inset-y-0 right-0 w-1 rounded-r-xl bg-gradient-to-b",
+                      frostgateGradient
+                    )}
+                  />
+                )}
+              </Link>
+            </TenantFeatureGate>
+          </TenantScopeGate>
         );
       })}
     </nav>

--- a/frontend/context/auth-context.tsx
+++ b/frontend/context/auth-context.tsx
@@ -12,12 +12,14 @@ export type TenantUser = {
   runeColor: string;
   plan: PlanTier;
   abilities: FeatureFlag[];
+  scopes: string[];
 };
 
 type AuthContextValue = {
   user: TenantUser;
   setPlan: (plan: PlanTier) => void;
   hasFeature: (feature: FeatureFlag) => boolean;
+  hasScope: (scope: string) => boolean;
 };
 
 const defaultUser: TenantUser = {
@@ -26,6 +28,23 @@ const defaultUser: TenantUser = {
   runeColor: "from-primary to-secondary",
   plan: "advanced",
   abilities: featureMatrix["advanced"],
+  scopes: [
+    "ui:posture:read",
+    "ui:decisions:read",
+    "ui:forensics:read",
+    "ui:audit:export",
+    "ui:controls:read",
+    "ui:training:read",
+    "ui:sites:read",
+    "ui:devices:read",
+    "ui:audit:read",
+    "ui:leaderboard:read",
+    "admin:tenant",
+    "admin:audit:read",
+    "admin:keys:write",
+    "admin:global",
+    "admin:quota:write",
+  ],
 };
 
 const AuthContext = createContext<AuthContextValue | undefined>(undefined);
@@ -45,6 +64,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           abilities: featureMatrix[plan],
         })),
       hasFeature: (feature) => matrix.includes(feature),
+      hasScope: (scope) => user.scopes.includes(scope) || user.scopes.includes("*"),
     };
   }, [user]);
 
@@ -73,6 +93,24 @@ export function TenantFeatureGate({
   const { hasFeature } = useAuth();
 
   if (!hasFeature(feature)) {
+    return <>{fallback}</>;
+  }
+
+  return <>{children}</>;
+}
+
+export function TenantScopeGate({
+  scope,
+  children,
+  fallback = null,
+}: {
+  scope: string;
+  children: ReactNode;
+  fallback?: ReactNode;
+}) {
+  const { hasScope } = useAuth();
+
+  if (!hasScope(scope)) {
     return <>{fallback}</>;
   }
 

--- a/frontend/lib/admin-api.ts
+++ b/frontend/lib/admin-api.ts
@@ -1,0 +1,32 @@
+"use server";
+
+const ADMIN_API_BASE = process.env.NEXT_PUBLIC_ADMIN_API_BASE ?? "http://localhost:8091";
+const DEFAULT_TENANT_ID = process.env.NEXT_PUBLIC_TENANT_ID ?? "11111111-1111-1111-1111-111111111111";
+
+type FetchOptions = {
+  scopes: string[];
+  method?: "GET" | "POST";
+  body?: object;
+};
+
+export async function fetchAdmin<T>(path: string, options: FetchOptions): Promise<T> {
+  const response = await fetch(`${ADMIN_API_BASE}${path}`, {
+    method: options.method ?? "GET",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Tenant-ID": DEFAULT_TENANT_ID,
+      "X-Scopes": options.scopes.join(" "),
+      "X-Subject": "admin-demo",
+      "X-Request-ID": "admin-demo-request",
+      "X-CSRF-Token": "admin-demo-csrf",
+    },
+    body: options.body ? JSON.stringify(options.body) : undefined,
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    throw new Error(`Admin API request failed: ${response.status}`);
+  }
+
+  return (await response.json()) as T;
+}

--- a/frontend/lib/feature-flags.ts
+++ b/frontend/lib/feature-flags.ts
@@ -1,5 +1,9 @@
 export const features = [
   "dashboards",
+  "posture",
+  "forensics",
+  "controls",
+  "admin-console",
   "training",
   "sites",
   "devices",
@@ -12,13 +16,38 @@ export type FeatureFlag = (typeof features)[number];
 export type FeatureMatrix = Record<string, FeatureFlag[]>;
 
 export const featureMatrix: FeatureMatrix = {
-  core: ["dashboards", "sites"],
-  advanced: ["dashboards", "training", "sites", "devices", "audit-stream"],
-  prime: ["dashboards", "training", "sites", "devices", "audit-stream", "leaderboard"],
+  core: ["dashboards", "posture", "forensics", "controls", "admin-console", "sites"],
+  advanced: [
+    "dashboards",
+    "posture",
+    "forensics",
+    "controls",
+    "admin-console",
+    "training",
+    "sites",
+    "devices",
+    "audit-stream",
+  ],
+  prime: [
+    "dashboards",
+    "posture",
+    "forensics",
+    "controls",
+    "admin-console",
+    "training",
+    "sites",
+    "devices",
+    "audit-stream",
+    "leaderboard",
+  ],
 };
 
 export const featureDescriptions: Record<FeatureFlag, string> = {
   dashboards: "Runic telemetry dashboards with streaming overlays.",
+  posture: "Security posture tiles and denial trend monitoring.",
+  forensics: "Chain of custody verification with evidence exports.",
+  controls: "Invariant proof matrix with remediation guidance.",
+  "admin-console": "Tenant admin controls, keys, quotas, and audit logs.",
   training: "Orchestrate FrostGate training rituals and rune calibration.",
   sites: "Manage gateways, shards, and geo-segmented wards.",
   devices: "Inspect guardian devices with pulse diagnostics.",

--- a/frontend/lib/navigation.tsx
+++ b/frontend/lib/navigation.tsx
@@ -8,6 +8,7 @@ export type NavItem = {
   description: string;
   icon: ComponentType<{ className?: string }>;
   feature: FeatureFlag;
+  scope: string;
 };
 
 export const navItems: NavItem[] = [
@@ -17,6 +18,39 @@ export const navItems: NavItem[] = [
     description: "Monitor resonance, wards, and runic anomalies in one glance.",
     icon: MonitorSmartphone,
     feature: "dashboards",
+    scope: "ui:posture:read",
+  },
+  {
+    name: "Security Posture",
+    href: "/posture",
+    description: "Track tenant posture tiles, trends, and denial drivers.",
+    icon: ShieldAlert,
+    feature: "posture",
+    scope: "ui:posture:read",
+  },
+  {
+    name: "Evidence & Forensics",
+    href: "/forensics",
+    description: "Verify chain-of-custody and export audit packets.",
+    icon: Sparkles,
+    feature: "forensics",
+    scope: "ui:forensics:read",
+  },
+  {
+    name: "Controls Matrix",
+    href: "/controls",
+    description: "Map invariants to evidence and remediation steps.",
+    icon: Cog,
+    feature: "controls",
+    scope: "ui:controls:read",
+  },
+  {
+    name: "Admin Console",
+    href: "/admin",
+    description: "Keys, quotas, and audit events for administrators.",
+    icon: BookA,
+    feature: "admin-console",
+    scope: "admin:tenant",
   },
   {
     name: "Training",
@@ -24,6 +58,7 @@ export const navItems: NavItem[] = [
     description: "Guide cadets through FrostGate drills and chronicle progress.",
     icon: Sparkles,
     feature: "training",
+    scope: "ui:training:read",
   },
   {
     name: "Sites & Segments",
@@ -31,6 +66,7 @@ export const navItems: NavItem[] = [
     description: "Map gate shards, environmental modifiers, and warding status.",
     icon: Network,
     feature: "sites",
+    scope: "ui:sites:read",
   },
   {
     name: "Devices",
@@ -38,6 +74,7 @@ export const navItems: NavItem[] = [
     description: "Inspect guardians, calibrate conduits, and sync rune firmware.",
     icon: Cog,
     feature: "devices",
+    scope: "ui:devices:read",
   },
   {
     name: "Audit Viewer",
@@ -45,6 +82,7 @@ export const navItems: NavItem[] = [
     description: "Trace audit glyphs and anomaly trails across the mesh logs.",
     icon: ShieldAlert,
     feature: "audit-stream",
+    scope: "ui:audit:read",
   },
   {
     name: "Leaderboard",
@@ -52,5 +90,6 @@ export const navItems: NavItem[] = [
     description: "Celebrate elite conductors ranked by resonance mastery.",
     icon: BookA,
     feature: "leaderboard",
+    scope: "ui:leaderboard:read",
   },
 ];

--- a/frontend/lib/ui-api.ts
+++ b/frontend/lib/ui-api.ts
@@ -1,0 +1,28 @@
+"use server";
+
+const UI_API_BASE = process.env.NEXT_PUBLIC_UI_API_BASE ?? "http://localhost:8090";
+const DEFAULT_TENANT_ID = process.env.NEXT_PUBLIC_TENANT_ID ?? "11111111-1111-1111-1111-111111111111";
+
+type FetchOptions = {
+  scopes: string[];
+  method?: "GET" | "POST";
+};
+
+export async function fetchUi<T>(path: string, options: FetchOptions): Promise<T> {
+  const response = await fetch(`${UI_API_BASE}${path}`, {
+    method: options.method ?? "GET",
+    headers: {
+      "X-Tenant-ID": DEFAULT_TENANT_ID,
+      "X-Scopes": options.scopes.join(" "),
+      "X-Subject": "ui-demo",
+      "X-Request-ID": "ui-demo-request",
+    },
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    throw new Error(`UI API request failed: ${response.status}`);
+  }
+
+  return (await response.json()) as T;
+}

--- a/tests/test_ui_dashboards.py
+++ b/tests/test_ui_dashboards.py
@@ -1,0 +1,137 @@
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from api import ui
+from api.storage import ControlInvariant, DashboardStore, Decision, build_chain
+
+
+def build_store() -> DashboardStore:
+    tenant_a = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+    tenant_b = uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+    created_at = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    decisions = [
+        Decision(
+            id="dec-a-1",
+            tenant_id=tenant_a,
+            created_at=created_at,
+            status="deny",
+            policy="network-egress",
+            reason="Blocked outbound",
+            actor="engine",
+            metadata={"severity": "high"},
+        ),
+        Decision(
+            id="dec-b-1",
+            tenant_id=tenant_b,
+            created_at=created_at,
+            status="allow",
+            policy="device-attest",
+            reason="Verified",
+            actor="engine",
+            metadata={"severity": "low"},
+        ),
+    ]
+    chain_a = build_chain(tenant_a, [{"event": "decision", "id": "dec-a-1"}])
+    chain_b = build_chain(tenant_b, [{"event": "decision", "id": "dec-b-1"}])
+    controls = [
+        ControlInvariant(
+            id="inv-a",
+            tenant_id=tenant_a,
+            name="Invariant A",
+            status="healthy",
+            remediation="Keep steady.",
+            evidence_links=["/ui/decision/dec-a-1"],
+        ),
+        ControlInvariant(
+            id="inv-b",
+            tenant_id=tenant_b,
+            name="Invariant B",
+            status="at_risk",
+            remediation="Fix soon.",
+            evidence_links=["/ui/decision/dec-b-1"],
+        ),
+    ]
+    return DashboardStore(decisions=decisions, chain=chain_a + chain_b, controls=controls)
+
+
+def headers(tenant_id: uuid.UUID, scopes: list[str]) -> dict:
+    return {
+        "X-Tenant-ID": str(tenant_id),
+        "X-Scopes": " ".join(scopes),
+        "X-Subject": "tester",
+    }
+
+
+def test_tenant_scoping_for_decisions():
+    store = build_store()
+    ui.app.dependency_overrides[ui.get_store] = lambda: store
+    client = TestClient(ui.app)
+
+    tenant_a = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+    response = client.get("/ui/decisions", headers=headers(tenant_a, ["ui:decisions:read"]))
+    assert response.status_code == 200
+    payload = response.json()
+    assert all(item["id"].startswith("dec-a") for item in payload["items"])
+
+    tenant_b = uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+    response = client.get("/ui/decisions", headers=headers(tenant_b, ["ui:decisions:read"]))
+    payload = response.json()
+    assert all(item["id"].startswith("dec-b") for item in payload["items"])
+    ui.app.dependency_overrides = {}
+
+
+def test_scope_enforcement_blocks_missing_scope():
+    store = build_store()
+    ui.app.dependency_overrides[ui.get_store] = lambda: store
+    client = TestClient(ui.app)
+    tenant_a = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+
+    response = client.get("/ui/posture", headers=headers(tenant_a, []))
+    assert response.status_code == 403
+    ui.app.dependency_overrides = {}
+
+
+def test_chain_verification_pass_and_fail():
+    store = build_store()
+    ui.app.dependency_overrides[ui.get_store] = lambda: store
+    client = TestClient(ui.app)
+    tenant_a = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+
+    response = client.get(
+        "/ui/forensics/chain/verify", headers=headers(tenant_a, ["ui:forensics:read"])
+    )
+    assert response.status_code == 200
+    assert response.json()["status"] == "PASS"
+
+    store.chain[0].hash = "tampered"
+    response = client.get(
+        "/ui/forensics/chain/verify", headers=headers(tenant_a, ["ui:forensics:read"])
+    )
+    assert response.status_code == 200
+    assert response.json()["status"] == "FAIL"
+    ui.app.dependency_overrides = {}
+
+
+def test_evidence_pack_manifest_deterministic(tmp_path: Path, monkeypatch):
+    store = build_store()
+    ui.app.dependency_overrides[ui.get_store] = lambda: store
+    client = TestClient(ui.app)
+    tenant_a = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+    monkeypatch.setenv("UI_PACKETS_DIR", str(tmp_path))
+
+    response = client.post("/ui/audit/packet", headers=headers(tenant_a, ["ui:audit:export"]))
+    assert response.status_code == 200
+    payload = response.json()
+    token_one = payload["token"]
+    manifest_files = {item["file"] for item in payload["manifest"]["files"]}
+    assert {"decisions.jsonl", "chain_verification.json"}.issubset(manifest_files)
+    bundle_path = Path(payload["path"])
+    assert (bundle_path / "manifest.json").exists()
+
+    response = client.post("/ui/audit/packet", headers=headers(tenant_a, ["ui:audit:export"]))
+    payload_two = response.json()
+    assert token_one == payload_two["token"]
+    ui.app.dependency_overrides = {}


### PR DESCRIPTION
### Motivation
- Provide tenant-safe, scope-protected dashboard surfaces and an audit-grade evidence export flow that prevent cross-tenant data leakage and record admin actions for auditability.
- Surface chain-of-custody verification and a deterministic evidence bundle for forensic exports while ensuring server-side scope checks and request correlation.

### Description
- Add security primitives in `api/security.py`: tenant binding dependency, scope-checking decorator `require_scopes`, CSRF header enforcement for state-changing requests, and request-ID middleware/dependency.
- Implement an in-memory demo store and evidence tooling in `api/storage.py`: decision/chain/control models, chain build/verify, deterministic `build_evidence_pack()` writing `decisions.jsonl`, `chain_verification.json`, `manifest.json` and optionally `sbom.json`/`provenance.json`, plus TTL cleanup of artifacts.
- Add UI-facing API in `api/ui.py`: tenant-scoped, scope-protected endpoints `GET /ui/posture`, `GET /ui/decisions` (paginated + filters), `GET /ui/decision/{id}`, `GET /ui/forensics/chain/verify`, `POST /ui/audit/packet` (export), `GET /ui/controls` and `GET /ui/controls/{inv_id}`; all return `request_id` and enforce tenant+scope server-side.
- Add admin gateway in `admin_gateway/app.py`: tenant and global console endpoints, paged audit-log, CSRF-protected state-changing actions (`/admin/console/keys/rotate`, `/admin/console/tenants/{tenant_id}/quota`) and structured audit events recorded to the store with `request_id` correlation.
- Frontend changes: `frontend/lib/ui-api.ts` and `frontend/lib/admin-api.ts` helpers that include tenant headers/scopes/request id; navigation and feature-flag updates; scope-driven nav gating and new UI pages for Posture, Forensics (with export UI), Controls (list + detail), and Admin console/actions.
- Tests & docs: `tests/test_ui_dashboards.py` covering tenant scoping, scope enforcement, chain verification PASS/FAIL on tamper, and deterministic evidence-pack manifest; `docs/dashboards.md` and README link; CI target `ci-hardening` and workflow job wired to run the test.

### Testing
- Ran `pytest tests/test_ui_dashboards.py` and all tests passed (4 passed).
- Added `make ci-hardening` and a `ci-hardening` job in `.github/workflows/rollup-ci.yml` to run the dashboard hardening tests in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69817d9323ac832cb4fff24dc4c2856b)